### PR TITLE
feat: add market review warehouse and dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 # 构建产物
 frontend/dist/
 *.local
+.worktrees/
 
 # IDE
 .idea/

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,11 +1,12 @@
 # API v1 package
 from fastapi import APIRouter
 
-from app.api.v1 import limit_up, statistics, market, config, websocket
+from app.api.v1 import config, limit_up, market, review, statistics, websocket
 
 api_router = APIRouter()
 
 api_router.include_router(limit_up.router, prefix="/limit-up", tags=["涨停"])
 api_router.include_router(statistics.router, prefix="/statistics", tags=["统计"])
+api_router.include_router(review.router, prefix="/statistics/review", tags=["复盘"])
 api_router.include_router(market.router, prefix="/market", tags=["行情"])
 api_router.include_router(config.router, prefix="/config", tags=["配置"])

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,11 +1,12 @@
 # API v1 package
 from fastapi import APIRouter
 
-from app.api.v1 import limit_up, statistics, market, config, websocket
+from app.api.v1 import config, daily_analysis, limit_up, market, statistics, websocket
 
 api_router = APIRouter()
 
 api_router.include_router(limit_up.router, prefix="/limit-up", tags=["涨停"])
 api_router.include_router(statistics.router, prefix="/statistics", tags=["统计"])
+api_router.include_router(daily_analysis.router, prefix="/statistics/daily-analysis", tags=["每日分析"])
 api_router.include_router(market.router, prefix="/market", tags=["行情"])
 api_router.include_router(config.router, prefix="/config", tags=["配置"])

--- a/backend/app/api/v1/daily_analysis.py
+++ b/backend/app/api/v1/daily_analysis.py
@@ -1,0 +1,55 @@
+from datetime import date
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.services.daily_analysis_service import daily_analysis_service
+
+
+router = APIRouter()
+
+
+class DailyAnalysisOverrideRequest(BaseModel):
+    overrides: Dict[str, Optional[str]] = Field(default_factory=dict, description="列名到人工覆盖内容")
+
+
+class DailyAnalysisBackfillRequest(BaseModel):
+    month: Optional[str] = Field(None, description="月份，格式 YYYY-MM")
+
+
+@router.get("", summary="获取每日分析月表")
+async def get_daily_analysis_month(
+    month: Optional[str] = Query(None, description="月份，格式 YYYY-MM"),
+    db: AsyncSession = Depends(get_db),
+):
+    if month is None:
+        month = date.today().strftime("%Y-%m")
+    return await daily_analysis_service.get_month(db, month)
+
+
+@router.post("/backfill", summary="回填每日分析")
+async def backfill_daily_analysis(
+    payload: DailyAnalysisBackfillRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    return await daily_analysis_service.backfill(db, payload.month)
+
+
+@router.post("/{trade_date}/rebuild", summary="重算单日每日分析")
+async def rebuild_daily_analysis(
+    trade_date: date,
+    db: AsyncSession = Depends(get_db),
+):
+    return await daily_analysis_service.rebuild_for_date(db, trade_date)
+
+
+@router.patch("/{trade_date}/overrides", summary="更新每日分析人工覆盖")
+async def update_daily_analysis_overrides(
+    trade_date: date,
+    payload: DailyAnalysisOverrideRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    return await daily_analysis_service.update_overrides(db, trade_date, payload.overrides)

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -1,0 +1,110 @@
+"""
+市场复盘API
+"""
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockDaily
+from app.schemas.market_review import (
+    MarketReviewDailyData,
+    MarketReviewDailyMetricRow,
+    MarketReviewDailyResponse,
+    MarketReviewDetailResponse,
+    MarketReviewLadderItem,
+    MarketReviewLadderResponse,
+    MarketReviewStockItem,
+)
+
+router = APIRouter()
+
+
+@router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")
+async def get_market_review_daily(
+    start_date: date | None = Query(None, description="开始日期"),
+    end_date: date | None = Query(None, description="结束日期"),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取市场复盘日级指标列表。"""
+    query = select(MarketReviewDailyMetric)
+
+    if start_date:
+        query = query.where(MarketReviewDailyMetric.trade_date >= start_date)
+    if end_date:
+        query = query.where(MarketReviewDailyMetric.trade_date <= end_date)
+
+    result = await db.execute(query.order_by(MarketReviewDailyMetric.trade_date.asc()))
+    rows = [MarketReviewDailyMetricRow.model_validate(row) for row in result.scalars().all()]
+
+    return MarketReviewDailyResponse(
+        data=MarketReviewDailyData(
+            series=[row.trade_date for row in rows],
+            rows=rows,
+        )
+    )
+
+
+@router.get("/detail", response_model=MarketReviewDetailResponse, summary="获取复盘个股明细")
+async def get_market_review_detail(
+    trade_date: date = Query(..., description="交易日期"),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取指定交易日的市场复盘个股明细。"""
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(MarketReviewStockDaily.trade_date == trade_date)
+        .order_by(
+            MarketReviewStockDaily.today_continuous_days.desc(),
+            MarketReviewStockDaily.amount.desc(),
+        )
+    )
+    stocks = [MarketReviewStockItem.model_validate(row) for row in result.scalars().all()]
+
+    return MarketReviewDetailResponse(
+        trade_date=trade_date,
+        stocks=stocks,
+    )
+
+
+@router.get("/ladder", response_model=MarketReviewLadderResponse, summary="获取复盘连板梯队")
+async def get_market_review_ladder(
+    trade_date: date = Query(..., description="交易日期"),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取指定交易日的市场复盘连板梯队。"""
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(
+            MarketReviewStockDaily.trade_date == trade_date,
+            MarketReviewStockDaily.today_touched_limit_up.is_(True),
+            MarketReviewStockDaily.today_continuous_days >= 2,
+        )
+        .order_by(
+            MarketReviewStockDaily.today_continuous_days.desc(),
+            MarketReviewStockDaily.amount.desc(),
+        )
+    )
+
+    ladders: list[MarketReviewLadderItem] = []
+    current_ladder: MarketReviewLadderItem | None = None
+
+    for row in result.scalars().all():
+        stock = MarketReviewStockItem.model_validate(row)
+        if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
+            current_ladder = MarketReviewLadderItem(
+                continuous_days=stock.today_continuous_days,
+                count=0,
+                stocks=[],
+            )
+            ladders.append(current_ladder)
+
+        current_ladder.stocks.append(stock)
+        current_ladder.count = len(current_ladder.stocks)
+
+    return MarketReviewLadderResponse(
+        trade_date=trade_date,
+        ladders=ladders,
+    )

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -74,6 +74,7 @@ async def _resolve_daily_metric_range(
 async def get_market_review_daily(
     start_date: date | None = Query(None, description="开始日期"),
     end_date: date | None = Query(None, description="结束日期"),
+    days: int | None = Query(None, ge=1, le=250, description="最近N个复盘交易日"),
     db: AsyncSession = Depends(get_db),
 ):
     """获取市场复盘日级指标列表。"""
@@ -82,8 +83,32 @@ async def get_market_review_daily(
         start_date,
         end_date,
     )
-    query = select(MarketReviewDailyMetric)
 
+    if days is not None:
+        query = select(MarketReviewDailyMetric)
+        if resolved_end_date:
+            query = query.where(MarketReviewDailyMetric.trade_date <= resolved_end_date)
+        result = await db.execute(
+            query.order_by(MarketReviewDailyMetric.trade_date.desc()).limit(days)
+        )
+        rows = [
+            MarketReviewDailyMetricRow.model_validate(row)
+            for row in reversed(result.scalars().all())
+        ]
+        return MarketReviewDailyResponse(
+            data=MarketReviewDailyData(
+                series=[row.trade_date for row in rows],
+                rows=rows,
+            ),
+            requested_start_date=start_date,
+            requested_end_date=end_date,
+            start_date=rows[0].trade_date if rows else resolved_start_date,
+            end_date=rows[-1].trade_date if rows else resolved_end_date,
+            latest_trade_date=latest_trade_date,
+            is_fallback=is_fallback,
+        )
+
+    query = select(MarketReviewDailyMetric)
     if resolved_start_date:
         query = query.where(MarketReviewDailyMetric.trade_date >= resolved_start_date)
     if resolved_end_date:

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -4,7 +4,7 @@
 from datetime import date
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -20,6 +20,23 @@ from app.schemas.market_review import (
 )
 
 router = APIRouter()
+
+
+async def _resolve_review_trade_date(
+    db: AsyncSession,
+    requested_date: date,
+) -> tuple[date, bool]:
+    """按复盘明细表解析实际可用的交易日期。"""
+    result = await db.execute(
+        select(MarketReviewStockDaily.trade_date)
+        .where(MarketReviewStockDaily.trade_date <= requested_date)
+        .order_by(desc(MarketReviewStockDaily.trade_date))
+        .limit(1)
+    )
+    resolved_date = result.scalar_one_or_none()
+    if resolved_date is None:
+        return requested_date, False
+    return resolved_date, resolved_date != requested_date
 
 
 @router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")
@@ -53,9 +70,10 @@ async def get_market_review_detail(
     db: AsyncSession = Depends(get_db),
 ):
     """获取指定交易日的市场复盘个股明细。"""
+    resolved_date, is_fallback = await _resolve_review_trade_date(db, trade_date)
     result = await db.execute(
         select(MarketReviewStockDaily)
-        .where(MarketReviewStockDaily.trade_date == trade_date)
+        .where(MarketReviewStockDaily.trade_date == resolved_date)
         .order_by(
             MarketReviewStockDaily.today_continuous_days.desc(),
             MarketReviewStockDaily.amount.desc(),
@@ -64,7 +82,8 @@ async def get_market_review_detail(
     stocks = [MarketReviewStockItem.model_validate(row) for row in result.scalars().all()]
 
     return MarketReviewDetailResponse(
-        trade_date=trade_date,
+        trade_date=resolved_date,
+        is_fallback=is_fallback,
         stocks=stocks,
     )
 
@@ -75,16 +94,19 @@ async def get_market_review_ladder(
     db: AsyncSession = Depends(get_db),
 ):
     """获取指定交易日的市场复盘连板梯队。"""
+    resolved_date, is_fallback = await _resolve_review_trade_date(db, trade_date)
     result = await db.execute(
         select(MarketReviewStockDaily)
         .where(
-            MarketReviewStockDaily.trade_date == trade_date,
+            MarketReviewStockDaily.trade_date == resolved_date,
             MarketReviewStockDaily.today_touched_limit_up.is_(True),
             MarketReviewStockDaily.today_continuous_days >= 2,
         )
         .order_by(
             MarketReviewStockDaily.today_continuous_days.desc(),
-            MarketReviewStockDaily.amount.desc(),
+            MarketReviewStockDaily.today_sealed_close.desc(),
+            MarketReviewStockDaily.first_limit_time.asc(),
+            MarketReviewStockDaily.stock_code.asc(),
         )
     )
 
@@ -105,6 +127,7 @@ async def get_market_review_ladder(
         current_ladder.count = len(current_ladder.stocks)
 
     return MarketReviewLadderResponse(
-        trade_date=trade_date,
+        trade_date=resolved_date,
+        is_fallback=is_fallback,
         ladders=ladders,
     )

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -39,6 +39,37 @@ async def _resolve_review_trade_date(
     return resolved_date, resolved_date != requested_date
 
 
+async def _resolve_daily_metric_range(
+    db: AsyncSession,
+    start_date: date | None,
+    end_date: date | None,
+) -> tuple[date | None, date | None, date | None, bool]:
+    """把日线查询锚定到最新已有复盘指标，避免今日未生成时返回空图。"""
+    latest_query = (
+        select(MarketReviewDailyMetric.trade_date)
+        .order_by(desc(MarketReviewDailyMetric.trade_date))
+        .limit(1)
+    )
+    if end_date is not None:
+        latest_query = latest_query.where(MarketReviewDailyMetric.trade_date <= end_date)
+
+    result = await db.execute(latest_query)
+    latest_trade_date = result.scalar_one_or_none()
+    if latest_trade_date is None:
+        return start_date, end_date, None, False
+
+    resolved_end_date = end_date
+    if resolved_end_date is None or resolved_end_date > latest_trade_date:
+        resolved_end_date = latest_trade_date
+
+    resolved_start_date = start_date
+    if resolved_start_date is not None and resolved_start_date > resolved_end_date:
+        resolved_start_date = resolved_end_date
+
+    is_fallback = resolved_start_date != start_date or resolved_end_date != end_date
+    return resolved_start_date, resolved_end_date, latest_trade_date, is_fallback
+
+
 @router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")
 async def get_market_review_daily(
     start_date: date | None = Query(None, description="开始日期"),
@@ -46,12 +77,17 @@ async def get_market_review_daily(
     db: AsyncSession = Depends(get_db),
 ):
     """获取市场复盘日级指标列表。"""
+    resolved_start_date, resolved_end_date, latest_trade_date, is_fallback = await _resolve_daily_metric_range(
+        db,
+        start_date,
+        end_date,
+    )
     query = select(MarketReviewDailyMetric)
 
-    if start_date:
-        query = query.where(MarketReviewDailyMetric.trade_date >= start_date)
-    if end_date:
-        query = query.where(MarketReviewDailyMetric.trade_date <= end_date)
+    if resolved_start_date:
+        query = query.where(MarketReviewDailyMetric.trade_date >= resolved_start_date)
+    if resolved_end_date:
+        query = query.where(MarketReviewDailyMetric.trade_date <= resolved_end_date)
 
     result = await db.execute(query.order_by(MarketReviewDailyMetric.trade_date.asc()))
     rows = [MarketReviewDailyMetricRow.model_validate(row) for row in result.scalars().all()]
@@ -60,7 +96,13 @@ async def get_market_review_daily(
         data=MarketReviewDailyData(
             series=[row.trade_date for row in rows],
             rows=rows,
-        )
+        ),
+        requested_start_date=start_date,
+        requested_end_date=end_date,
+        start_date=rows[0].trade_date if rows else resolved_start_date,
+        end_date=rows[-1].trade_date if rows else resolved_end_date,
+        latest_trade_date=latest_trade_date,
+        is_fallback=is_fallback,
     )
 
 

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -1,7 +1,8 @@
 """
 市场复盘API
 """
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import desc, select
@@ -14,12 +15,21 @@ from app.schemas.market_review import (
     MarketReviewDailyMetricRow,
     MarketReviewDailyResponse,
     MarketReviewDetailResponse,
+    MarketReviewIntradayResponse,
     MarketReviewLadderItem,
     MarketReviewLadderResponse,
     MarketReviewStockItem,
 )
+from app.services.market_review_metrics_service import market_review_metrics_service
 
 router = APIRouter()
+CN_TZ = timezone(timedelta(hours=8))
+
+
+async def _collect_intraday_source(trade_date: date) -> dict[str, Any]:
+    from app.services.market_review_source_service import market_review_source_service
+
+    return await market_review_source_service.collect(trade_date)
 
 
 async def _resolve_review_trade_date(
@@ -71,7 +81,7 @@ async def _resolve_daily_metric_range(
 
 
 def _format_board_height_label(
-    stock_rows: list[MarketReviewStockDaily],
+    stock_rows: list[MarketReviewStockDaily | dict[str, Any]],
     height: int,
     board_types: set[str] | None = None,
 ) -> str | None:
@@ -79,12 +89,143 @@ def _format_board_height_label(
         return None
 
     names = [
-        f"{row.stock_name}{height}"
+        f"{_get_stock_value(row, 'stock_name')}{height}"
         for row in stock_rows
-        if row.today_continuous_days == height
-        and (board_types is None or row.board_type in board_types)
+        if _get_stock_int(row, "today_continuous_days") == height
+        and (board_types is None or _get_stock_value(row, "board_type") in board_types)
     ]
     return "\n".join(names) if names else None
+
+
+def _get_stock_value(row: MarketReviewStockDaily | dict[str, Any], key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _get_stock_int(row: MarketReviewStockDaily | dict[str, Any], key: str) -> int:
+    try:
+        return int(_get_stock_value(row, key, 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _get_stock_float(row: MarketReviewStockDaily | dict[str, Any], key: str) -> float | None:
+    value = _get_stock_value(row, key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_stock_item_from_source(row: dict[str, Any]) -> MarketReviewStockItem:
+    change_pct = _get_stock_float(row, "change_pct")
+    return MarketReviewStockItem(
+        stock_code=str(row.get("stock_code") or ""),
+        stock_name=str(row.get("stock_name") or row.get("stock_code") or ""),
+        today_continuous_days=_get_stock_int(row, "today_continuous_days"),
+        today_sealed_close=bool(row.get("today_sealed_close")),
+        today_opened_close=bool(row.get("today_opened_close") or row.get("today_broken")),
+        change_pct=change_pct,
+        amount=float(row.get("amount") or 0.0),
+        limit_up_reason=row.get("limit_up_reason") or None,
+    )
+
+
+def _build_intraday_detail(trade_date: date, stock_rows: list[dict[str, Any]]) -> MarketReviewDetailResponse:
+    stocks = [_build_stock_item_from_source(row) for row in stock_rows if row.get("stock_code")]
+    stocks.sort(
+        key=lambda stock: (
+            -stock.today_continuous_days,
+            -stock.amount,
+            stock.stock_code,
+        )
+    )
+    return MarketReviewDetailResponse(
+        trade_date=trade_date,
+        is_fallback=False,
+        stocks=stocks,
+    )
+
+
+def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -> MarketReviewLadderResponse:
+    stocks = [
+        _build_stock_item_from_source(row)
+        for row in stock_rows
+        if row.get("today_touched_limit_up") and _get_stock_int(row, "today_continuous_days") >= 2
+    ]
+    stocks.sort(
+        key=lambda stock: (
+            -stock.today_continuous_days,
+            not stock.today_sealed_close,
+            stock.stock_code,
+        )
+    )
+
+    ladders: list[MarketReviewLadderItem] = []
+    current_ladder: MarketReviewLadderItem | None = None
+    for stock in stocks:
+        if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
+            current_ladder = MarketReviewLadderItem(
+                continuous_days=stock.today_continuous_days,
+                count=0,
+                stocks=[],
+            )
+            ladders.append(current_ladder)
+
+        current_ladder.stocks.append(stock)
+        current_ladder.count = len(current_ladder.stocks)
+
+    return MarketReviewLadderResponse(
+        trade_date=trade_date,
+        is_fallback=False,
+        ladders=ladders,
+    )
+
+
+async def _build_intraday_snapshot(trade_date: date) -> MarketReviewIntradayResponse:
+    normalized_data = await _collect_intraday_source(trade_date)
+    stock_rows = normalized_data.get("stock_rows") or []
+    metric = market_review_metrics_service.aggregate_daily_metrics(
+        trade_date,
+        stock_rows,
+        int(normalized_data.get("limit_down_count") or 0),
+        float(normalized_data.get("market_turnover") or 0.0),
+        int(normalized_data.get("up_count_ex_st") or 0),
+        int(normalized_data.get("down_count_ex_st") or 0),
+    )
+    metric_row = MarketReviewDailyMetricRow.model_validate(metric)
+    labels = {
+        "max_board_label": _format_board_height_label(stock_rows, metric_row.max_board_height),
+        "second_board_label": _format_board_height_label(stock_rows, metric_row.second_board_height),
+        "gem_board_label": _format_board_height_label(
+            stock_rows,
+            metric_row.gem_board_height,
+            {"gem", "star"},
+        ),
+    }
+    metric_row = metric_row.model_copy(update=labels)
+
+    detail = _build_intraday_detail(metric_row.trade_date, stock_rows)
+    ladder = _build_intraday_ladder(metric_row.trade_date, stock_rows)
+
+    return MarketReviewIntradayResponse(
+        data=MarketReviewDailyData(
+            series=[metric_row.trade_date],
+            rows=[metric_row],
+        ),
+        requested_start_date=trade_date,
+        requested_end_date=trade_date,
+        start_date=metric_row.trade_date,
+        end_date=metric_row.trade_date,
+        latest_trade_date=metric_row.trade_date,
+        is_fallback=False,
+        snapshot_time=datetime.now(CN_TZ),
+        detail=detail,
+        ladder=ladder,
+    )
 
 
 async def _attach_board_height_labels(
@@ -130,6 +271,15 @@ async def _attach_board_height_labels(
         rows.append(MarketReviewDailyMetricRow.model_validate(metric_row).model_copy(update=labels))
 
     return rows
+
+
+@router.get("/intraday", response_model=MarketReviewIntradayResponse, summary="获取盘中复盘快照")
+async def get_market_review_intraday(
+    trade_date: date | None = Query(None, description="交易日期，默认今天"),
+):
+    """获取盘中实时复盘快照。"""
+    target_date = trade_date or datetime.now(CN_TZ).date()
+    return await _build_intraday_snapshot(target_date)
 
 
 @router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -24,6 +24,7 @@ from app.services.market_review_metrics_service import market_review_metrics_ser
 
 router = APIRouter()
 CN_TZ = timezone(timedelta(hours=8))
+_TRADING_DAY_CACHE: dict[date, bool] = {}
 
 
 async def _collect_intraday_source(trade_date: date) -> dict[str, Any]:
@@ -253,12 +254,52 @@ def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -
     return _build_ladder_response_from_rows(trade_date, False, stock_rows)
 
 
+def _normalize_cn_trade_calendar_date(raw_value: Any) -> date | None:
+    if isinstance(raw_value, datetime):
+        return raw_value.date()
+    if isinstance(raw_value, date):
+        return raw_value
+    if isinstance(raw_value, str):
+        return datetime.strptime(raw_value, "%Y-%m-%d").date()
+    if hasattr(raw_value, "date"):
+        return raw_value.date()
+    return None
+
+
+def _load_cn_trading_dates(start_date: date, end_date: date) -> set[date]:
+    import akshare as ak
+
+    calendar_df = ak.tool_trade_date_hist_sina()
+    if "trade_date" not in calendar_df:
+        return set()
+
+    trading_dates: set[date] = set()
+    for raw_value in calendar_df["trade_date"].tolist():
+        trade_date = _normalize_cn_trade_calendar_date(raw_value)
+        if trade_date is not None and start_date <= trade_date <= end_date:
+            trading_dates.add(trade_date)
+    return trading_dates
+
+
+def _is_cn_trading_day(trade_date: date) -> bool:
+    if trade_date.weekday() >= 5:
+        return False
+    if trade_date not in _TRADING_DAY_CACHE:
+        try:
+            _TRADING_DAY_CACHE[trade_date] = trade_date in _load_cn_trading_dates(trade_date, trade_date)
+        except Exception:
+            _TRADING_DAY_CACHE[trade_date] = True
+    return _TRADING_DAY_CACHE[trade_date]
+
+
 def _should_collect_live_intraday(trade_date: date) -> bool:
     now = datetime.now(CN_TZ)
-    return trade_date == now.date() and time(9, 15) <= now.time() <= time(15, 30)
+    if trade_date != now.date() or not _is_cn_trading_day(trade_date):
+        return False
+    return time(9, 15) <= now.time() <= time(15, 0)
 
 
-async def _build_intraday_snapshot(trade_date: date) -> MarketReviewIntradayResponse:
+async def _build_intraday_snapshot(trade_date: date, is_live: bool = True) -> MarketReviewIntradayResponse:
     normalized_data = await _collect_intraday_source(trade_date)
     stock_rows = normalized_data.get("stock_rows") or []
     metric = market_review_metrics_service.aggregate_daily_metrics(
@@ -295,6 +336,7 @@ async def _build_intraday_snapshot(trade_date: date) -> MarketReviewIntradayResp
         end_date=metric_row.trade_date,
         latest_trade_date=metric_row.trade_date,
         is_fallback=False,
+        is_live=is_live,
         snapshot_time=datetime.now(CN_TZ),
         detail=detail,
         ladder=ladder,
@@ -387,6 +429,7 @@ async def _build_stored_intraday_snapshot(
         end_date=daily_row.trade_date,
         latest_trade_date=daily_row.trade_date,
         is_fallback=is_fallback,
+        is_live=False,
         snapshot_time=datetime.now(CN_TZ),
         detail=detail,
         ladder=ladder,
@@ -448,7 +491,7 @@ async def get_market_review_intraday(
 
     if _should_collect_live_intraday(target_date):
         try:
-            return await _build_intraday_snapshot(target_date)
+            return await _build_intraday_snapshot(target_date, is_live=True)
         except Exception:
             stored_snapshot = await _build_stored_intraday_snapshot(db, target_date)
             if stored_snapshot is not None:
@@ -459,7 +502,7 @@ async def get_market_review_intraday(
     if stored_snapshot is not None:
         return stored_snapshot
 
-    return await _build_intraday_snapshot(target_date)
+    return await _build_intraday_snapshot(target_date, is_live=False)
 
 
 @router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -29,7 +29,7 @@ CN_TZ = timezone(timedelta(hours=8))
 async def _collect_intraday_source(trade_date: date) -> dict[str, Any]:
     from app.services.market_review_source_service import market_review_source_service
 
-    return await market_review_source_service.collect(trade_date)
+    return await market_review_source_service.collect_for_date(trade_date)
 
 
 async def _resolve_review_trade_date(

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -1,7 +1,7 @@
 """
 市场复盘API
 """
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query
@@ -185,6 +185,11 @@ def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -
     )
 
 
+def _should_collect_live_intraday(trade_date: date) -> bool:
+    now = datetime.now(CN_TZ)
+    return trade_date == now.date() and time(9, 15) <= now.time() <= time(15, 30)
+
+
 async def _build_intraday_snapshot(trade_date: date) -> MarketReviewIntradayResponse:
     normalized_data = await _collect_intraday_source(trade_date)
     stock_rows = normalized_data.get("stock_rows") or []
@@ -222,6 +227,118 @@ async def _build_intraday_snapshot(trade_date: date) -> MarketReviewIntradayResp
         end_date=metric_row.trade_date,
         latest_trade_date=metric_row.trade_date,
         is_fallback=False,
+        snapshot_time=datetime.now(CN_TZ),
+        detail=detail,
+        ladder=ladder,
+    )
+
+
+async def _build_detail_response_from_db(
+    db: AsyncSession,
+    resolved_date: date,
+    is_fallback: bool,
+) -> MarketReviewDetailResponse:
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(MarketReviewStockDaily.trade_date == resolved_date)
+        .order_by(
+            MarketReviewStockDaily.today_continuous_days.desc(),
+            MarketReviewStockDaily.amount.desc(),
+        )
+    )
+    stocks = [MarketReviewStockItem.model_validate(row) for row in result.scalars().all()]
+
+    return MarketReviewDetailResponse(
+        trade_date=resolved_date,
+        is_fallback=is_fallback,
+        stocks=stocks,
+    )
+
+
+async def _build_ladder_response_from_db(
+    db: AsyncSession,
+    resolved_date: date,
+    is_fallback: bool,
+) -> MarketReviewLadderResponse:
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(
+            MarketReviewStockDaily.trade_date == resolved_date,
+            MarketReviewStockDaily.today_touched_limit_up.is_(True),
+            MarketReviewStockDaily.today_continuous_days >= 2,
+        )
+        .order_by(
+            MarketReviewStockDaily.today_continuous_days.desc(),
+            MarketReviewStockDaily.today_sealed_close.desc(),
+            MarketReviewStockDaily.first_limit_time.asc(),
+            MarketReviewStockDaily.stock_code.asc(),
+        )
+    )
+
+    ladders: list[MarketReviewLadderItem] = []
+    current_ladder: MarketReviewLadderItem | None = None
+
+    for row in result.scalars().all():
+        stock = MarketReviewStockItem.model_validate(row)
+        if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
+            current_ladder = MarketReviewLadderItem(
+                continuous_days=stock.today_continuous_days,
+                count=0,
+                stocks=[],
+            )
+            ladders.append(current_ladder)
+
+        current_ladder.stocks.append(stock)
+        current_ladder.count = len(current_ladder.stocks)
+
+    return MarketReviewLadderResponse(
+        trade_date=resolved_date,
+        is_fallback=is_fallback,
+        ladders=ladders,
+    )
+
+
+async def _build_stored_intraday_snapshot(
+    db: AsyncSession,
+    requested_date: date,
+) -> MarketReviewIntradayResponse | None:
+    result = await db.execute(
+        select(MarketReviewDailyMetric)
+        .where(MarketReviewDailyMetric.trade_date == requested_date)
+        .limit(1)
+    )
+    metric_row = result.scalar_one_or_none()
+    is_fallback = False
+
+    if metric_row is None:
+        result = await db.execute(
+            select(MarketReviewDailyMetric)
+            .where(MarketReviewDailyMetric.trade_date <= requested_date)
+            .order_by(desc(MarketReviewDailyMetric.trade_date))
+            .limit(1)
+        )
+        metric_row = result.scalar_one_or_none()
+        is_fallback = metric_row is not None
+
+    if metric_row is None:
+        return None
+
+    rows = await _attach_board_height_labels(db, [metric_row])
+    daily_row = rows[0] if rows else MarketReviewDailyMetricRow.model_validate(metric_row)
+    detail = await _build_detail_response_from_db(db, daily_row.trade_date, is_fallback)
+    ladder = await _build_ladder_response_from_db(db, daily_row.trade_date, is_fallback)
+
+    return MarketReviewIntradayResponse(
+        data=MarketReviewDailyData(
+            series=[daily_row.trade_date],
+            rows=[daily_row],
+        ),
+        requested_start_date=requested_date,
+        requested_end_date=requested_date,
+        start_date=daily_row.trade_date,
+        end_date=daily_row.trade_date,
+        latest_trade_date=daily_row.trade_date,
+        is_fallback=is_fallback,
         snapshot_time=datetime.now(CN_TZ),
         detail=detail,
         ladder=ladder,
@@ -276,9 +393,24 @@ async def _attach_board_height_labels(
 @router.get("/intraday", response_model=MarketReviewIntradayResponse, summary="获取盘中复盘快照")
 async def get_market_review_intraday(
     trade_date: date | None = Query(None, description="交易日期，默认今天"),
+    db: AsyncSession = Depends(get_db),
 ):
     """获取盘中实时复盘快照。"""
     target_date = trade_date or datetime.now(CN_TZ).date()
+
+    if _should_collect_live_intraday(target_date):
+        try:
+            return await _build_intraday_snapshot(target_date)
+        except Exception:
+            stored_snapshot = await _build_stored_intraday_snapshot(db, target_date)
+            if stored_snapshot is not None:
+                return stored_snapshot
+            raise
+
+    stored_snapshot = await _build_stored_intraday_snapshot(db, target_date)
+    if stored_snapshot is not None:
+        return stored_snapshot
+
     return await _build_intraday_snapshot(target_date)
 
 
@@ -347,21 +479,7 @@ async def get_market_review_detail(
 ):
     """获取指定交易日的市场复盘个股明细。"""
     resolved_date, is_fallback = await _resolve_review_trade_date(db, trade_date)
-    result = await db.execute(
-        select(MarketReviewStockDaily)
-        .where(MarketReviewStockDaily.trade_date == resolved_date)
-        .order_by(
-            MarketReviewStockDaily.today_continuous_days.desc(),
-            MarketReviewStockDaily.amount.desc(),
-        )
-    )
-    stocks = [MarketReviewStockItem.model_validate(row) for row in result.scalars().all()]
-
-    return MarketReviewDetailResponse(
-        trade_date=resolved_date,
-        is_fallback=is_fallback,
-        stocks=stocks,
-    )
+    return await _build_detail_response_from_db(db, resolved_date, is_fallback)
 
 
 @router.get("/ladder", response_model=MarketReviewLadderResponse, summary="获取复盘连板梯队")
@@ -371,39 +489,4 @@ async def get_market_review_ladder(
 ):
     """获取指定交易日的市场复盘连板梯队。"""
     resolved_date, is_fallback = await _resolve_review_trade_date(db, trade_date)
-    result = await db.execute(
-        select(MarketReviewStockDaily)
-        .where(
-            MarketReviewStockDaily.trade_date == resolved_date,
-            MarketReviewStockDaily.today_touched_limit_up.is_(True),
-            MarketReviewStockDaily.today_continuous_days >= 2,
-        )
-        .order_by(
-            MarketReviewStockDaily.today_continuous_days.desc(),
-            MarketReviewStockDaily.today_sealed_close.desc(),
-            MarketReviewStockDaily.first_limit_time.asc(),
-            MarketReviewStockDaily.stock_code.asc(),
-        )
-    )
-
-    ladders: list[MarketReviewLadderItem] = []
-    current_ladder: MarketReviewLadderItem | None = None
-
-    for row in result.scalars().all():
-        stock = MarketReviewStockItem.model_validate(row)
-        if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
-            current_ladder = MarketReviewLadderItem(
-                continuous_days=stock.today_continuous_days,
-                count=0,
-                stocks=[],
-            )
-            ladders.append(current_ladder)
-
-        current_ladder.stocks.append(stock)
-        current_ladder.count = len(current_ladder.stocks)
-
-    return MarketReviewLadderResponse(
-        trade_date=resolved_date,
-        is_fallback=is_fallback,
-        ladders=ladders,
-    )
+    return await _build_ladder_response_from_db(db, resolved_date, is_fallback)

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -134,6 +134,12 @@ def _build_stock_item_from_source(row: dict[str, Any]) -> MarketReviewStockItem:
     )
 
 
+def _build_stock_item(row: MarketReviewStockDaily | dict[str, Any]) -> MarketReviewStockItem:
+    if isinstance(row, dict):
+        return _build_stock_item_from_source(row)
+    return MarketReviewStockItem.model_validate(row)
+
+
 def _build_intraday_detail(trade_date: date, stock_rows: list[dict[str, Any]]) -> MarketReviewDetailResponse:
     stocks = [_build_stock_item_from_source(row) for row in stock_rows if row.get("stock_code")]
     stocks.sort(
@@ -150,23 +156,79 @@ def _build_intraday_detail(trade_date: date, stock_rows: list[dict[str, Any]]) -
     )
 
 
-def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -> MarketReviewLadderResponse:
-    stocks = [
-        _build_stock_item_from_source(row)
-        for row in stock_rows
-        if row.get("today_touched_limit_up") and _get_stock_int(row, "today_continuous_days") >= 2
-    ]
-    stocks.sort(
-        key=lambda stock: (
-            -stock.today_continuous_days,
-            not stock.today_sealed_close,
-            stock.stock_code,
+def _is_ladder_display_row(row: MarketReviewStockDaily | dict[str, Any]) -> bool:
+    return bool(_get_stock_value(row, "today_touched_limit_up")) and _get_stock_int(row, "today_continuous_days") >= 2
+
+
+def _is_same_ladder_cohort_row(row: MarketReviewStockDaily | dict[str, Any], continuous_days: int) -> bool:
+    if continuous_days <= 1:
+        return False
+
+    previous_days = continuous_days - 1
+    yesterday_days = _get_stock_int(row, "yesterday_continuous_days")
+    if previous_days == 1 and bool(_get_stock_value(row, "yesterday_limit_up")) and yesterday_days in (0, 1):
+        return True
+    if yesterday_days == previous_days:
+        return True
+
+    return (
+        _is_ladder_display_row(row)
+        and _get_stock_int(row, "today_continuous_days") == continuous_days
+        and yesterday_days == 0
+    )
+
+
+def _apply_ladder_cohort_metrics(
+    ladders: list[MarketReviewLadderItem],
+    stock_rows: list[MarketReviewStockDaily | dict[str, Any]],
+) -> None:
+    for ladder in ladders:
+        cohort_rows = [
+            row
+            for row in stock_rows
+            if _is_same_ladder_cohort_row(row, ladder.continuous_days)
+        ]
+        if not cohort_rows:
+            cohort_rows = ladder.stocks
+
+        changes = [
+            change
+            for change in (_get_stock_float(row, "change_pct") for row in cohort_rows)
+            if change is not None
+        ]
+        cohort_count = len(cohort_rows)
+        cohort_sealed_count = sum(1 for row in cohort_rows if bool(_get_stock_value(row, "today_sealed_close")))
+        cohort_opened_count = sum(
+            1
+            for row in cohort_rows
+            if bool(_get_stock_value(row, "today_opened_close") or _get_stock_value(row, "today_broken"))
+        )
+
+        ladder.cohort_count = cohort_count
+        ladder.cohort_sealed_count = cohort_sealed_count
+        ladder.cohort_opened_count = cohort_opened_count
+        ladder.cohort_seal_rate = round(cohort_sealed_count * 100 / cohort_count, 2) if cohort_count else 0.0
+        ladder.cohort_avg_change = round(sum(changes) / len(changes), 2) if changes else None
+
+
+def _build_ladder_response_from_rows(
+    trade_date: date,
+    is_fallback: bool,
+    stock_rows: list[MarketReviewStockDaily | dict[str, Any]],
+) -> MarketReviewLadderResponse:
+    ladder_rows = [row for row in stock_rows if _is_ladder_display_row(row)]
+    ladder_rows.sort(
+        key=lambda row: (
+            -_get_stock_int(row, "today_continuous_days"),
+            not bool(_get_stock_value(row, "today_sealed_close")),
+            str(_get_stock_value(row, "stock_code", "")),
         )
     )
 
     ladders: list[MarketReviewLadderItem] = []
     current_ladder: MarketReviewLadderItem | None = None
-    for stock in stocks:
+    for row in ladder_rows:
+        stock = _build_stock_item(row)
         if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
             current_ladder = MarketReviewLadderItem(
                 continuous_days=stock.today_continuous_days,
@@ -178,11 +240,17 @@ def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -
         current_ladder.stocks.append(stock)
         current_ladder.count = len(current_ladder.stocks)
 
+    _apply_ladder_cohort_metrics(ladders, stock_rows)
+
     return MarketReviewLadderResponse(
         trade_date=trade_date,
-        is_fallback=False,
+        is_fallback=is_fallback,
         ladders=ladders,
     )
+
+
+def _build_intraday_ladder(trade_date: date, stock_rows: list[dict[str, Any]]) -> MarketReviewLadderResponse:
+    return _build_ladder_response_from_rows(trade_date, False, stock_rows)
 
 
 def _should_collect_live_intraday(trade_date: date) -> bool:
@@ -262,11 +330,7 @@ async def _build_ladder_response_from_db(
 ) -> MarketReviewLadderResponse:
     result = await db.execute(
         select(MarketReviewStockDaily)
-        .where(
-            MarketReviewStockDaily.trade_date == resolved_date,
-            MarketReviewStockDaily.today_touched_limit_up.is_(True),
-            MarketReviewStockDaily.today_continuous_days >= 2,
-        )
+        .where(MarketReviewStockDaily.trade_date == resolved_date)
         .order_by(
             MarketReviewStockDaily.today_continuous_days.desc(),
             MarketReviewStockDaily.today_sealed_close.desc(),
@@ -275,26 +339,10 @@ async def _build_ladder_response_from_db(
         )
     )
 
-    ladders: list[MarketReviewLadderItem] = []
-    current_ladder: MarketReviewLadderItem | None = None
-
-    for row in result.scalars().all():
-        stock = MarketReviewStockItem.model_validate(row)
-        if current_ladder is None or current_ladder.continuous_days != stock.today_continuous_days:
-            current_ladder = MarketReviewLadderItem(
-                continuous_days=stock.today_continuous_days,
-                count=0,
-                stocks=[],
-            )
-            ladders.append(current_ladder)
-
-        current_ladder.stocks.append(stock)
-        current_ladder.count = len(current_ladder.stocks)
-
-    return MarketReviewLadderResponse(
+    return _build_ladder_response_from_rows(
         trade_date=resolved_date,
         is_fallback=is_fallback,
-        ladders=ladders,
+        stock_rows=list(result.scalars().all()),
     )
 
 

--- a/backend/app/api/v1/review.py
+++ b/backend/app/api/v1/review.py
@@ -70,6 +70,68 @@ async def _resolve_daily_metric_range(
     return resolved_start_date, resolved_end_date, latest_trade_date, is_fallback
 
 
+def _format_board_height_label(
+    stock_rows: list[MarketReviewStockDaily],
+    height: int,
+    board_types: set[str] | None = None,
+) -> str | None:
+    if height <= 0:
+        return None
+
+    names = [
+        f"{row.stock_name}{height}"
+        for row in stock_rows
+        if row.today_continuous_days == height
+        and (board_types is None or row.board_type in board_types)
+    ]
+    return "\n".join(names) if names else None
+
+
+async def _attach_board_height_labels(
+    db: AsyncSession,
+    metric_rows: list[MarketReviewDailyMetric],
+) -> list[MarketReviewDailyMetricRow]:
+    if not metric_rows:
+        return []
+
+    trade_dates = [row.trade_date for row in metric_rows]
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(
+            MarketReviewStockDaily.trade_date.in_(trade_dates),
+            MarketReviewStockDaily.today_touched_limit_up.is_(True),
+            MarketReviewStockDaily.today_continuous_days > 0,
+        )
+        .order_by(
+            MarketReviewStockDaily.trade_date.asc(),
+            MarketReviewStockDaily.today_continuous_days.desc(),
+            MarketReviewStockDaily.today_sealed_close.desc(),
+            MarketReviewStockDaily.first_limit_time.asc(),
+            MarketReviewStockDaily.stock_code.asc(),
+        )
+    )
+
+    stocks_by_date: dict[date, list[MarketReviewStockDaily]] = {}
+    for stock_row in result.scalars().all():
+        stocks_by_date.setdefault(stock_row.trade_date, []).append(stock_row)
+
+    rows: list[MarketReviewDailyMetricRow] = []
+    for metric_row in metric_rows:
+        stock_rows = stocks_by_date.get(metric_row.trade_date, [])
+        labels = {
+            "max_board_label": _format_board_height_label(stock_rows, metric_row.max_board_height),
+            "second_board_label": _format_board_height_label(stock_rows, metric_row.second_board_height),
+            "gem_board_label": _format_board_height_label(
+                stock_rows,
+                metric_row.gem_board_height,
+                {"gem", "star"},
+            ),
+        }
+        rows.append(MarketReviewDailyMetricRow.model_validate(metric_row).model_copy(update=labels))
+
+    return rows
+
+
 @router.get("/daily", response_model=MarketReviewDailyResponse, summary="获取复盘日级指标")
 async def get_market_review_daily(
     start_date: date | None = Query(None, description="开始日期"),
@@ -91,10 +153,7 @@ async def get_market_review_daily(
         result = await db.execute(
             query.order_by(MarketReviewDailyMetric.trade_date.desc()).limit(days)
         )
-        rows = [
-            MarketReviewDailyMetricRow.model_validate(row)
-            for row in reversed(result.scalars().all())
-        ]
+        rows = await _attach_board_height_labels(db, list(reversed(result.scalars().all())))
         return MarketReviewDailyResponse(
             data=MarketReviewDailyData(
                 series=[row.trade_date for row in rows],
@@ -115,7 +174,7 @@ async def get_market_review_daily(
         query = query.where(MarketReviewDailyMetric.trade_date <= resolved_end_date)
 
     result = await db.execute(query.order_by(MarketReviewDailyMetric.trade_date.asc()))
-    rows = [MarketReviewDailyMetricRow.model_validate(row) for row in result.scalars().all()]
+    rows = await _attach_board_height_labels(db, list(result.scalars().all()))
 
     return MarketReviewDailyResponse(
         data=MarketReviewDailyData(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -60,6 +60,14 @@ class Settings(BaseSettings):
     MARKET_CLOSE_TIME: str = "15:00"
     MARKET_LUNCH_START: str = "11:30"
     MARKET_LUNCH_END: str = "13:00"
+
+    # 市场复盘配置
+    MARKET_REVIEW_ENABLED: bool = True
+    MARKET_REVIEW_BUILD_HOUR: int = 15
+    MARKET_REVIEW_BUILD_MINUTE: int = 5
+    MARKET_REVIEW_REPAIR_HOUR: int = 20
+    MARKET_REVIEW_REPAIR_MINUTE: int = 15
+    MARKET_REVIEW_REPAIR_ENABLED: bool = True
     
     # 日志配置
     LOG_LEVEL: str = "INFO"

--- a/backend/app/data_collectors/scheduler.py
+++ b/backend/app/data_collectors/scheduler.py
@@ -10,6 +10,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
 
 from app.config import settings
+from app.services.market_review_pipeline_service import market_review_pipeline_service
 from app.utils.time_utils import is_trading_time, get_market_status
 
 
@@ -71,6 +72,30 @@ class DataScheduler:
             id="clear_cache",
             name="每日缓存清理"
         )
+
+        if settings.MARKET_REVIEW_ENABLED:
+            self.scheduler.add_job(
+                self._build_market_review,
+                CronTrigger(
+                    hour=settings.MARKET_REVIEW_BUILD_HOUR,
+                    minute=settings.MARKET_REVIEW_BUILD_MINUTE,
+                ),
+                id="market_review_build",
+                name="市场复盘构建",
+                max_instances=1,
+            )
+
+            if settings.MARKET_REVIEW_REPAIR_ENABLED:
+                self.scheduler.add_job(
+                    self._repair_market_review,
+                    CronTrigger(
+                        hour=settings.MARKET_REVIEW_REPAIR_HOUR,
+                        minute=settings.MARKET_REVIEW_REPAIR_MINUTE,
+                    ),
+                    id="market_review_repair",
+                    name="市场复盘修复",
+                    max_instances=1,
+                )
         
         self.scheduler.start()
         self._is_running = True
@@ -360,6 +385,22 @@ class DataScheduler:
         
         except Exception as e:
             logger.error(f"Clear cache error: {e}")
+
+    async def _build_market_review(self):
+        """构建当日市场复盘数据"""
+        try:
+            await market_review_pipeline_service.run_for_date(date.today(), calc_version=1)
+            logger.info("Market review build completed")
+        except Exception as e:
+            logger.error(f"Market review build error: {e}")
+
+    async def _repair_market_review(self):
+        """修复当日市场复盘数据"""
+        try:
+            await market_review_pipeline_service.run_for_date(date.today(), calc_version=2)
+            logger.info("Market review repair completed")
+        except Exception as e:
+            logger.error(f"Market review repair error: {e}")
 
 
 # 全局调度器实例

--- a/backend/app/data_collectors/scheduler.py
+++ b/backend/app/data_collectors/scheduler.py
@@ -3,7 +3,7 @@
 """
 import asyncio
 from datetime import datetime, time, date
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
@@ -11,7 +11,52 @@ from loguru import logger
 
 from app.config import settings
 from app.services.market_review_pipeline_service import market_review_pipeline_service
-from app.utils.time_utils import is_trading_time, get_market_status
+from app.utils.time_utils import CN_TZ, get_market_status, is_trading_time, today_cn
+
+
+def _normalize_trade_calendar_date(raw_value) -> Optional[date]:
+    if isinstance(raw_value, date):
+        return raw_value
+    if hasattr(raw_value, "date"):
+        return raw_value.date()
+    if isinstance(raw_value, str):
+        return datetime.strptime(raw_value, "%Y-%m-%d").date()
+    return None
+
+
+def _get_cn_trading_dates(start_date: date, end_date: date) -> List[date]:
+    if end_date < start_date:
+        return []
+
+    try:
+        import akshare as ak
+
+        calendar_df = ak.tool_trade_date_hist_sina()
+    except Exception as exc:
+        logger.warning(f"Unable to resolve China trading calendar, skipping market review work: {exc}")
+        return []
+
+    if "trade_date" not in calendar_df:
+        logger.warning("China trading calendar missing trade_date column, skipping market review work")
+        return []
+
+    trading_dates: List[date] = []
+    for raw_value in calendar_df["trade_date"].tolist():
+        trade_date = _normalize_trade_calendar_date(raw_value)
+        if trade_date is None:
+            continue
+        if start_date <= trade_date <= end_date:
+            trading_dates.append(trade_date)
+
+    return trading_dates
+
+
+def _resolve_cn_trade_date_for_market_review(current_date: Optional[date] = None) -> Optional[date]:
+    resolved_date = current_date or today_cn()
+    trading_dates = _get_cn_trading_dates(resolved_date, resolved_date)
+    if not trading_dates:
+        return None
+    return resolved_date
 
 
 class DataScheduler:
@@ -79,6 +124,7 @@ class DataScheduler:
                 CronTrigger(
                     hour=settings.MARKET_REVIEW_BUILD_HOUR,
                     minute=settings.MARKET_REVIEW_BUILD_MINUTE,
+                    timezone=CN_TZ,
                 ),
                 id="market_review_build",
                 name="市场复盘构建",
@@ -91,6 +137,7 @@ class DataScheduler:
                     CronTrigger(
                         hour=settings.MARKET_REVIEW_REPAIR_HOUR,
                         minute=settings.MARKET_REVIEW_REPAIR_MINUTE,
+                        timezone=CN_TZ,
                     ),
                     id="market_review_repair",
                     name="市场复盘修复",
@@ -389,7 +436,11 @@ class DataScheduler:
     async def _build_market_review(self):
         """构建当日市场复盘数据"""
         try:
-            await market_review_pipeline_service.run_for_date(date.today(), calc_version=1)
+            trade_date = _resolve_cn_trade_date_for_market_review()
+            if trade_date is None:
+                logger.info("Skipping market review build because current China date is not a trading day")
+                return
+            await market_review_pipeline_service.run_for_date(trade_date, calc_version=1)
             logger.info("Market review build completed")
         except Exception as e:
             logger.error(f"Market review build error: {e}")
@@ -397,7 +448,11 @@ class DataScheduler:
     async def _repair_market_review(self):
         """修复当日市场复盘数据"""
         try:
-            await market_review_pipeline_service.run_for_date(date.today(), calc_version=2)
+            trade_date = _resolve_cn_trade_date_for_market_review()
+            if trade_date is None:
+                logger.info("Skipping market review repair because current China date is not a trading day")
+                return
+            await market_review_pipeline_service.run_for_date(trade_date, calc_version=2)
             logger.info("Market review repair completed")
         except Exception as e:
             logger.error(f"Market review repair error: {e}")

--- a/backend/app/data_collectors/scheduler.py
+++ b/backend/app/data_collectors/scheduler.py
@@ -14,6 +14,10 @@ from app.services.market_review_pipeline_service import market_review_pipeline_s
 from app.utils.time_utils import CN_TZ, get_market_status, is_trading_time, today_cn
 
 
+class TradingCalendarLookupError(RuntimeError):
+    """Raised when the China trading calendar cannot be loaded reliably."""
+
+
 def _normalize_trade_calendar_date(raw_value) -> Optional[date]:
     if isinstance(raw_value, date):
         return raw_value
@@ -33,12 +37,14 @@ def _get_cn_trading_dates(start_date: date, end_date: date) -> List[date]:
 
         calendar_df = ak.tool_trade_date_hist_sina()
     except Exception as exc:
-        logger.warning(f"Unable to resolve China trading calendar, skipping market review work: {exc}")
-        return []
+        raise TradingCalendarLookupError(
+            f"Unable to resolve China trading calendar for market review work: {exc}"
+        ) from exc
 
     if "trade_date" not in calendar_df:
-        logger.warning("China trading calendar missing trade_date column, skipping market review work")
-        return []
+        raise TradingCalendarLookupError(
+            "China trading calendar missing trade_date column for market review work"
+        )
 
     trading_dates: List[date] = []
     for raw_value in calendar_df["trade_date"].tolist():
@@ -444,6 +450,7 @@ class DataScheduler:
             logger.info("Market review build completed")
         except Exception as e:
             logger.error(f"Market review build error: {e}")
+            raise
 
     async def _repair_market_review(self):
         """修复当日市场复盘数据"""
@@ -456,6 +463,7 @@ class DataScheduler:
             logger.info("Market review repair completed")
         except Exception as e:
             logger.error(f"Market review repair error: {e}")
+            raise
 
 
 # 全局调度器实例

--- a/backend/app/data_collectors/scheduler.py
+++ b/backend/app/data_collectors/scheduler.py
@@ -63,6 +63,15 @@ class DataScheduler:
             id="daily_stats",
             name="每日统计计算"
         )
+
+        # 收盘后每日分析月表（默认复用市场复盘任务时间）
+        self.scheduler.add_job(
+            self._calculate_daily_analysis,
+            CronTrigger(hour=settings.MARKET_REVIEW_BUILD_HOUR, minute=settings.MARKET_REVIEW_BUILD_MINUTE),
+            id="daily_analysis",
+            name="每日分析月表生成",
+            max_instances=1
+        )
         
         # 每日缓存清理（每天16:00）
         self.scheduler.add_job(
@@ -346,6 +355,20 @@ class DataScheduler:
         
         except Exception as e:
             logger.error(f"Calculate daily stats error: {e}")
+
+    async def _calculate_daily_analysis(self):
+        """生成每日分析月表数据"""
+        try:
+            from app.database import async_session_maker
+            from app.services.daily_analysis_service import daily_analysis_service
+
+            today = date.today()
+            async with async_session_maker() as db:
+                await daily_analysis_service.build_for_date(db, today)
+
+            logger.info(f"Daily analysis calculated: {today}")
+        except Exception as e:
+            logger.error(f"Calculate daily analysis error: {e}")
     
     async def _clear_daily_cache(self):
         """清理每日缓存"""

--- a/backend/app/data_collectors/scheduler.py
+++ b/backend/app/data_collectors/scheduler.py
@@ -445,10 +445,15 @@ class DataScheduler:
             from app.services.daily_analysis_service import daily_analysis_service
 
             today = date.today()
-            async with async_session_maker() as db:
-                await daily_analysis_service.build_for_date(db, today)
+            resolved_trade_date = _resolve_cn_trade_date_for_market_review(today)
+            if resolved_trade_date is None:
+                logger.info("Skipping daily analysis build because current China date is not a trading day")
+                return
 
-            logger.info(f"Daily analysis calculated: {today}")
+            async with async_session_maker() as db:
+                await daily_analysis_service.build_for_date(db, resolved_trade_date)
+
+            logger.info(f"Daily analysis calculated: {resolved_trade_date}")
         except Exception as e:
             logger.error(f"Calculate daily analysis error: {e}")
     

--- a/backend/app/data_collectors/tencent_api.py
+++ b/backend/app/data_collectors/tencent_api.py
@@ -5,6 +5,8 @@ import httpx
 from typing import Dict, List, Optional
 from loguru import logger
 
+from app.utils.market_data_sanitizer import normalize_change_pct
+
 
 class TencentStockAPI:
     """腾讯股票实时行情API"""
@@ -108,6 +110,12 @@ class TencentStockAPI:
                             result[name] = 0
                     else:
                         result[name] = value
+
+            result["change_pct"] = normalize_change_pct(
+                result.get("change_pct"),
+                price=result.get("price"),
+                amount=result.get("amount"),
+            )
             
             return result
         except Exception as e:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,8 @@
 """
 数据库连接和会话管理
 """
+from importlib import import_module
+
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy import event
@@ -44,6 +46,9 @@ async def get_db() -> AsyncSession:
 
 async def init_db():
     """初始化数据库（创建所有表）"""
+    # Ensure all model modules are imported before metadata.create_all() runs.
+    import_module("app.models")
+
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.v1.websocket import router as ws_router
 from app.core.event_bus import event_bus
 from app.utils.logger import setup_logging, logger
 from app.services.data_init_service import data_init_service
+from app.data_collectors.scheduler import data_scheduler
 
 
 @asynccontextmanager
@@ -29,6 +30,9 @@ async def lifespan(app: FastAPI):
     # 启动事件总线
     await event_bus.start()
     logger.info("EventBus started")
+
+    # 启动定时采集/盘后复盘任务
+    data_scheduler.start()
     
     # 自动爬取最近交易日数据（后台任务）
     asyncio.create_task(data_init_service.initialize())
@@ -36,6 +40,7 @@ async def lifespan(app: FastAPI):
     yield
     
     # 关闭时
+    data_scheduler.stop()
     await event_bus.stop()
     await close_db()
     logger.info("Application shutdown complete")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.v1.websocket import router as ws_router
 from app.core.event_bus import event_bus
 from app.utils.logger import setup_logging, logger
 from app.services.data_init_service import data_init_service
+from app.data_collectors.scheduler import data_scheduler
 
 
 @asynccontextmanager
@@ -32,10 +33,14 @@ async def lifespan(app: FastAPI):
     
     # 自动爬取最近交易日数据（后台任务）
     asyncio.create_task(data_init_service.initialize())
+
+    # 启动定时任务：盘中采集、盘后统计、每日分析
+    data_scheduler.start()
     
     yield
     
     # 关闭时
+    data_scheduler.stop()
     await event_bus.stop()
     await close_db()
     logger.info("Application shutdown complete")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,13 @@
 """Models package."""
 
-from app.models.market_review import (  # noqa: F401
+from .market_review import (  # noqa: F401
     MarketReviewDailyMetric,
     MarketReviewLimitUpEvent,
     MarketReviewStockDaily,
 )
+
+__all__ = [
+    "MarketReviewDailyMetric",
+    "MarketReviewLimitUpEvent",
+    "MarketReviewStockDaily",
+]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,13 +1,27 @@
 """Models package."""
 
+from .big_order import BigOrder  # noqa: F401
+from .limit_up import LimitUpRecord, LimitUpStatusChange  # noqa: F401
+from .market_data import CrawlerTask, DailyStatistics, DataValidation, UserConfig  # noqa: F401
 from .market_review import (  # noqa: F401
     MarketReviewDailyMetric,
     MarketReviewLimitUpEvent,
     MarketReviewStockDaily,
 )
+from .order_flow import OrderBookSnapshot  # noqa: F401
+from .stock import Stock  # noqa: F401
 
 __all__ = [
+    "BigOrder",
+    "CrawlerTask",
+    "DailyStatistics",
+    "DataValidation",
+    "LimitUpRecord",
+    "LimitUpStatusChange",
     "MarketReviewDailyMetric",
     "MarketReviewLimitUpEvent",
     "MarketReviewStockDaily",
+    "OrderBookSnapshot",
+    "Stock",
+    "UserConfig",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,7 @@
-# Models package
+"""Models package."""
+
+from app.models.market_review import (  # noqa: F401
+    MarketReviewDailyMetric,
+    MarketReviewLimitUpEvent,
+    MarketReviewStockDaily,
+)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 """Models package."""
 
 from app.models.market_review import (  # noqa: F401
+    DailyAnalysisRecord,
     MarketReviewDailyMetric,
     MarketReviewLimitUpEvent,
     MarketReviewStockDaily,

--- a/backend/app/models/market_review.py
+++ b/backend/app/models/market_review.py
@@ -1,0 +1,112 @@
+"""
+市场复盘相关模型
+"""
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    JSON,
+    String,
+    Time,
+    UniqueConstraint,
+)
+
+from app.database import Base
+
+
+class MarketReviewDailyMetric(Base):
+    """市场复盘日级指标表"""
+
+    __tablename__ = "market_review_daily_metric"
+    __table_args__ = (
+        UniqueConstraint("trade_date", name="uq_review_metric_trade_date"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False, comment="交易日期")
+    limit_up_count = Column(Integer, default=0, nullable=False, comment="涨停数量")
+    limit_down_count = Column(Integer, default=0, nullable=False, comment="跌停数量")
+    continuous_count = Column(Integer, default=0, nullable=False, comment="连板数量")
+    max_board_height = Column(Integer, default=0, nullable=False, comment="最高板高度")
+    second_board_height = Column(Integer, default=0, nullable=False, comment="二板高度")
+    gem_board_height = Column(Integer, default=0, nullable=False, comment="创业板高度")
+    first_to_second_rate = Column(Float, default=0, nullable=False, comment="首板晋级率")
+    continuous_promotion_rate = Column(Float, default=0, nullable=False, comment="连板晋级率")
+    seal_rate = Column(Float, default=0, nullable=False, comment="封板率")
+    yesterday_limit_up_avg_change = Column(Float, default=0, nullable=False, comment="昨日涨停均涨幅")
+    yesterday_continuous_avg_change = Column(Float, default=0, nullable=False, comment="昨日连板均涨幅")
+    market_turnover = Column(Float, default=0, nullable=False, comment="市场成交额")
+    up_count_ex_st = Column(Integer, default=0, nullable=False, comment="非ST上涨家数")
+    down_count_ex_st = Column(Integer, default=0, nullable=False, comment="非ST下跌家数")
+    limit_up_amount = Column(Float, default=0, nullable=False, comment="涨停成交额")
+    broken_amount = Column(Float, default=0, nullable=False, comment="炸板成交额")
+    calc_version = Column(Integer, default=1, nullable=False, comment="计算版本")
+    source_status = Column(String(20), default="primary", nullable=False, comment="来源状态")
+    created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False, comment="更新时间")
+
+
+class MarketReviewStockDaily(Base):
+    """市场复盘个股日级事实表"""
+
+    __tablename__ = "market_review_stock_daily"
+    __table_args__ = (
+        UniqueConstraint("trade_date", "stock_code", name="uq_review_stock_daily"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False, comment="交易日期")
+    stock_code = Column(String(10), nullable=False, comment="股票代码")
+    stock_name = Column(String(50), nullable=False, comment="股票名称")
+    board_type = Column(String(20), default="main", nullable=False, comment="板块类型")
+    is_st = Column(Boolean, default=False, nullable=False, comment="是否ST")
+    yesterday_limit_up = Column(Boolean, default=False, nullable=False, comment="昨日是否涨停")
+    yesterday_continuous_days = Column(Integer, default=0, nullable=False, comment="昨日连板天数")
+    today_touched_limit_up = Column(Boolean, default=False, nullable=False, comment="今日是否触板")
+    today_sealed_close = Column(Boolean, default=False, nullable=False, comment="今日收盘封死")
+    today_opened_close = Column(Boolean, default=False, nullable=False, comment="今日收盘开板")
+    today_broken = Column(Boolean, default=False, nullable=False, comment="今日炸板")
+    today_continuous_days = Column(Integer, default=0, nullable=False, comment="今日连板天数")
+    first_limit_time = Column(Time, comment="首次封板时间")
+    final_seal_time = Column(Time, comment="最终封板时间")
+    open_count = Column(Integer, default=0, nullable=False, comment="开板次数")
+    close_price = Column(Float, comment="收盘价")
+    pre_close = Column(Float, comment="昨收价")
+    change_pct = Column(Float, comment="涨跌幅")
+    amount = Column(Float, default=0, nullable=False, comment="成交额")
+    turnover_rate = Column(Float, comment="换手率")
+    tradable_market_value = Column(Float, comment="可流通市值")
+    limit_up_reason = Column(String(255), comment="涨停原因")
+    data_quality_flag = Column(String(20), default="ok", nullable=False, comment="数据质量标记")
+    created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False, comment="更新时间")
+
+
+class MarketReviewLimitUpEvent(Base):
+    """市场复盘涨停事件轨迹表"""
+
+    __tablename__ = "market_review_limitup_event"
+    __table_args__ = (
+        UniqueConstraint(
+            "trade_date",
+            "stock_code",
+            "event_type",
+            "event_seq",
+            name="uq_review_limitup_event",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False, index=True, comment="交易日期")
+    stock_code = Column(String(10), nullable=False, index=True, comment="股票代码")
+    event_type = Column(String(20), nullable=False, index=True, comment="事件类型")
+    event_time = Column(Time, comment="事件时间")
+    event_seq = Column(Integer, default=0, nullable=False, comment="事件序号")
+    source_name = Column(String(20), nullable=False, comment="来源名称")
+    payload_json = Column(JSON, default=dict, nullable=False, comment="事件载荷")
+    created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")

--- a/backend/app/models/market_review.py
+++ b/backend/app/models/market_review.py
@@ -9,12 +9,14 @@ from sqlalchemy import (
     Date,
     DateTime,
     Float,
+    ForeignKey,
     Integer,
     JSON,
     String,
     Time,
     UniqueConstraint,
 )
+from sqlalchemy.orm import relationship
 
 from app.database import Base
 
@@ -56,11 +58,12 @@ class MarketReviewStockDaily(Base):
 
     __tablename__ = "market_review_stock_daily"
     __table_args__ = (
-        UniqueConstraint("trade_date", "stock_code", name="uq_review_stock_daily"),
+        UniqueConstraint("trade_date", "stock_id", name="uq_review_stock_daily"),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     trade_date = Column(Date, nullable=False, comment="交易日期")
+    stock_id = Column(Integer, ForeignKey("stocks.id"), nullable=False, index=True, comment="股票ID")
     stock_code = Column(String(10), nullable=False, comment="股票代码")
     stock_name = Column(String(50), nullable=False, comment="股票名称")
     board_type = Column(String(20), default="main", nullable=False, comment="板块类型")
@@ -85,6 +88,7 @@ class MarketReviewStockDaily(Base):
     data_quality_flag = Column(String(20), default="ok", nullable=False, comment="数据质量标记")
     created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
     updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False, comment="更新时间")
+    stock = relationship("Stock")
 
 
 class MarketReviewLimitUpEvent(Base):
@@ -94,7 +98,7 @@ class MarketReviewLimitUpEvent(Base):
     __table_args__ = (
         UniqueConstraint(
             "trade_date",
-            "stock_code",
+            "stock_id",
             "event_type",
             "event_seq",
             name="uq_review_limitup_event",
@@ -103,6 +107,7 @@ class MarketReviewLimitUpEvent(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     trade_date = Column(Date, nullable=False, index=True, comment="交易日期")
+    stock_id = Column(Integer, ForeignKey("stocks.id"), nullable=False, index=True, comment="股票ID")
     stock_code = Column(String(10), nullable=False, index=True, comment="股票代码")
     event_type = Column(String(20), nullable=False, index=True, comment="事件类型")
     event_time = Column(Time, comment="事件时间")
@@ -110,3 +115,4 @@ class MarketReviewLimitUpEvent(Base):
     source_name = Column(String(20), nullable=False, comment="来源名称")
     payload_json = Column(JSON, default=dict, nullable=False, comment="事件载荷")
     created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
+    stock = relationship("Stock")

--- a/backend/app/models/market_review.py
+++ b/backend/app/models/market_review.py
@@ -58,7 +58,7 @@ class MarketReviewStockDaily(Base):
 
     __tablename__ = "market_review_stock_daily"
     __table_args__ = (
-        UniqueConstraint("trade_date", "stock_id", name="uq_review_stock_daily"),
+        UniqueConstraint("trade_date", "stock_code", name="uq_review_stock_daily"),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -98,7 +98,7 @@ class MarketReviewLimitUpEvent(Base):
     __table_args__ = (
         UniqueConstraint(
             "trade_date",
-            "stock_id",
+            "stock_code",
             "event_type",
             "event_seq",
             name="uq_review_limitup_event",

--- a/backend/app/models/market_review.py
+++ b/backend/app/models/market_review.py
@@ -110,3 +110,23 @@ class MarketReviewLimitUpEvent(Base):
     source_name = Column(String(20), nullable=False, comment="来源名称")
     payload_json = Column(JSON, default=dict, nullable=False, comment="事件载荷")
     created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
+
+
+class DailyAnalysisRecord(Base):
+    """每日分析月表结果"""
+
+    __tablename__ = "daily_analysis_records"
+    __table_args__ = (
+        UniqueConstraint("trade_date", name="uq_daily_analysis_trade_date"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False, comment="交易日期")
+    month = Column(String(7), nullable=False, index=True, comment="月份 YYYY-MM")
+    auto_result = Column(JSON, default=dict, nullable=False, comment="自动分析结果")
+    manual_overrides = Column(JSON, default=dict, nullable=False, comment="人工覆盖内容")
+    calc_version = Column(Integer, default=1, nullable=False, comment="计算版本")
+    data_status = Column(String(20), default="ready", nullable=False, comment="数据状态")
+    generated_at = Column(DateTime, default=datetime.now, nullable=False, comment="生成时间")
+    created_at = Column(DateTime, default=datetime.now, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False, comment="更新时间")

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -62,6 +62,7 @@ class MarketReviewDetailResponse(BaseModel):
     """市场复盘明细响应"""
 
     trade_date: date
+    is_fallback: bool = Field(False, description="是否回退到历史数据")
     stocks: list[MarketReviewStockItem] = Field(default_factory=list)
 
 
@@ -77,4 +78,5 @@ class MarketReviewLadderResponse(BaseModel):
     """市场复盘梯队响应"""
 
     trade_date: date
+    is_fallback: bool = Field(False, description="是否回退到历史数据")
     ladders: list[MarketReviewLadderItem] = Field(default_factory=list)

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -41,6 +41,12 @@ class MarketReviewDailyResponse(BaseModel):
     """市场复盘日级指标响应"""
 
     data: MarketReviewDailyData
+    requested_start_date: date | None = None
+    requested_end_date: date | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    latest_trade_date: date | None = None
+    is_fallback: bool = Field(False, description="是否回退到最近可用复盘日")
 
 
 class MarketReviewStockItem(BaseModel):

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -1,0 +1,80 @@
+"""
+市场复盘接口响应模型
+"""
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MarketReviewDailyMetricRow(BaseModel):
+    """市场复盘日级指标行"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    trade_date: date
+    limit_up_count: int
+    limit_down_count: int
+    continuous_count: int
+    max_board_height: int
+    second_board_height: int
+    gem_board_height: int
+    first_to_second_rate: float
+    continuous_promotion_rate: float
+    seal_rate: float
+    yesterday_limit_up_avg_change: float
+    yesterday_continuous_avg_change: float
+    market_turnover: float
+    up_count_ex_st: int
+    down_count_ex_st: int
+    limit_up_amount: float
+    broken_amount: float
+
+
+class MarketReviewDailyData(BaseModel):
+    """市场复盘日级指标数据块"""
+
+    series: list[date] = Field(default_factory=list)
+    rows: list[MarketReviewDailyMetricRow] = Field(default_factory=list)
+
+
+class MarketReviewDailyResponse(BaseModel):
+    """市场复盘日级指标响应"""
+
+    data: MarketReviewDailyData
+
+
+class MarketReviewStockItem(BaseModel):
+    """市场复盘个股条目"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    stock_code: str
+    stock_name: str
+    today_continuous_days: int
+    today_sealed_close: bool
+    today_opened_close: bool
+    change_pct: float | None = None
+    amount: float
+    limit_up_reason: str | None = None
+
+
+class MarketReviewDetailResponse(BaseModel):
+    """市场复盘明细响应"""
+
+    trade_date: date
+    stocks: list[MarketReviewStockItem] = Field(default_factory=list)
+
+
+class MarketReviewLadderItem(BaseModel):
+    """市场复盘梯队条目"""
+
+    continuous_days: int
+    count: int
+    stocks: list[MarketReviewStockItem] = Field(default_factory=list)
+
+
+class MarketReviewLadderResponse(BaseModel):
+    """市场复盘梯队响应"""
+
+    trade_date: date
+    ladders: list[MarketReviewLadderItem] = Field(default_factory=list)

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -1,7 +1,7 @@
 """
 市场复盘接口响应模型
 """
-from datetime import date
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -89,3 +89,12 @@ class MarketReviewLadderResponse(BaseModel):
     trade_date: date
     is_fallback: bool = Field(False, description="是否回退到历史数据")
     ladders: list[MarketReviewLadderItem] = Field(default_factory=list)
+
+
+class MarketReviewIntradayResponse(MarketReviewDailyResponse):
+    """市场复盘盘中快照响应"""
+
+    is_intraday: bool = Field(True, description="是否为盘中实时快照")
+    snapshot_time: datetime
+    detail: MarketReviewDetailResponse
+    ladder: MarketReviewLadderResponse

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -80,6 +80,11 @@ class MarketReviewLadderItem(BaseModel):
 
     continuous_days: int
     count: int
+    cohort_count: int = Field(0, description="同梯队样本数量，包含未晋级个股")
+    cohort_sealed_count: int = Field(0, description="同梯队封板数量")
+    cohort_opened_count: int = Field(0, description="同梯队炸板数量")
+    cohort_seal_rate: float = Field(0.0, description="同梯队封板率")
+    cohort_avg_change: float | None = Field(None, description="同梯队平均涨幅")
     stocks: list[MarketReviewStockItem] = Field(default_factory=list)
 
 

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -18,6 +18,9 @@ class MarketReviewDailyMetricRow(BaseModel):
     max_board_height: int
     second_board_height: int
     gem_board_height: int
+    max_board_label: str | None = None
+    second_board_label: str | None = None
+    gem_board_label: str | None = None
     first_to_second_rate: float
     continuous_promotion_rate: float
     seal_rate: float

--- a/backend/app/schemas/market_review.py
+++ b/backend/app/schemas/market_review.py
@@ -100,6 +100,7 @@ class MarketReviewIntradayResponse(MarketReviewDailyResponse):
     """市场复盘盘中快照响应"""
 
     is_intraday: bool = Field(True, description="是否为盘中实时快照")
+    is_live: bool = Field(False, description="是否为交易时段实时采集")
     snapshot_time: datetime
     detail: MarketReviewDetailResponse
     ladder: MarketReviewLadderResponse

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,1 @@
-# Services package
-from app.services.data_init_service import data_init_service
-
-__all__ = ["data_init_service"]
+"""Services package."""

--- a/backend/app/services/continuous_ladder_service.py
+++ b/backend/app/services/continuous_ladder_service.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional
 
+from app.utils.market_data_sanitizer import normalize_change_pct
+
 
 class ContinuousLadderService:
     """Build continuous ladder payloads from realtime limit-up data."""
@@ -32,7 +34,11 @@ class ContinuousLadderService:
                     "reason": item.get("limit_up_reason", ""),
                     "is_sealed": is_sealed,
                     "open_count": int(item.get("open_count") or 0),
-                    "change_pct": self._to_float(item.get("change_pct")),
+                    "change_pct": normalize_change_pct(
+                        item.get("change_pct"),
+                        price=item.get("current_price") or item.get("limit_up_price"),
+                        amount=item.get("amount"),
+                    ),
                     "bid1_volume": self._to_float(item.get("bid1_volume")),
                     "turnover_rate": self._to_float(item.get("turnover_rate")),
                     "real_turnover_rate": self._calculate_real_turnover_rate(item),
@@ -85,7 +91,11 @@ class ContinuousLadderService:
                     "stock_name": item.get("n", ""),
                     "yesterday_days": yesterday_days,
                     "today_status": today_status,
-                    "today_change_pct": self._to_float(item.get("zdp")),
+                    "today_change_pct": normalize_change_pct(
+                        item.get("zdp"),
+                        price=item.get("p"),
+                        amount=item.get("amount"),
+                    ),
                 }
             )
 

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -4,7 +4,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, time
 import re
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 from sqlalchemy import distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -645,6 +645,8 @@ class DailyAnalysisRuleEngine:
 class DailyAnalysisService:
     def __init__(self, rule_engine: Optional[DailyAnalysisRuleEngine] = None):
         self.rule_engine = rule_engine or DailyAnalysisRuleEngine()
+        self._cn_trading_calendar: Optional[Set[date]] = None
+        self._cn_trading_calendar_unavailable = False
 
     async def get_month(self, db: AsyncSession, month: str) -> Dict[str, Any]:
         records = await self._get_month_records(db, month)
@@ -659,11 +661,18 @@ class DailyAnalysisService:
 
     async def backfill(self, db: AsyncSession, month: Optional[str] = None) -> Dict[str, Any]:
         dates = await self._get_trade_dates(db, month)
+        removed = await self._delete_non_trading_records(db, month)
+        if removed:
+            await db.commit()
         built = []
         for trade_date in dates:
             await self.build_for_date(db, trade_date)
             built.append(trade_date.isoformat())
-        return {"built_count": len(built), "trade_dates": built}
+        return {
+            "built_count": len(built),
+            "trade_dates": built,
+            "removed_non_trading_count": removed,
+        }
 
     async def update_overrides(
         self,
@@ -806,7 +815,7 @@ class DailyAnalysisService:
             .limit(limit)
         )
         result = await db.execute(query)
-        return sorted([row[0] for row in result.all()])
+        return sorted(self._filter_trading_dates([row[0] for row in result.all()]))
 
     async def _get_trade_dates(self, db: AsyncSession, month: Optional[str]) -> List[date]:
         query = select(distinct(LimitUpRecord.trade_date)).where(LimitUpRecord.trade_date <= date.today())
@@ -815,7 +824,7 @@ class DailyAnalysisService:
             query = query.where(LimitUpRecord.trade_date >= start, LimitUpRecord.trade_date <= end)
         query = query.order_by(LimitUpRecord.trade_date)
         result = await db.execute(query)
-        return [row[0] for row in result.all()]
+        return self._filter_trading_dates([row[0] for row in result.all()])
 
     async def _get_month_records(self, db: AsyncSession, month: str) -> List[DailyAnalysisRecord]:
         query = (
@@ -824,7 +833,51 @@ class DailyAnalysisService:
             .order_by(DailyAnalysisRecord.trade_date.desc())
         )
         result = await db.execute(query)
-        return list(result.scalars().all())
+        records = list(result.scalars().all())
+        trading_dates = set(self._filter_trading_dates([record.trade_date for record in records]))
+        return [record for record in records if record.trade_date in trading_dates]
+
+    async def _delete_non_trading_records(self, db: AsyncSession, month: Optional[str]) -> int:
+        query = select(DailyAnalysisRecord).where(DailyAnalysisRecord.trade_date <= date.today())
+        if month:
+            start, end = self._month_bounds(month)
+            query = query.where(DailyAnalysisRecord.trade_date >= start, DailyAnalysisRecord.trade_date <= end)
+        result = await db.execute(query)
+        records = list(result.scalars().all())
+        trading_dates = set(self._filter_trading_dates([record.trade_date for record in records]))
+        removed = 0
+        for record in records:
+            if record.trade_date not in trading_dates:
+                await db.delete(record)
+                removed += 1
+        return removed
+
+    def _filter_trading_dates(self, dates: List[date]) -> List[date]:
+        ordered_dates = list(dict.fromkeys(dates))
+        if not ordered_dates:
+            return []
+
+        trading_dates = self._load_cn_trading_date_set(min(ordered_dates), max(ordered_dates))
+        if trading_dates is None:
+            return [value for value in ordered_dates if value.weekday() < 5]
+        return [value for value in ordered_dates if value in trading_dates]
+
+    def _load_cn_trading_date_set(self, start: date, end: date) -> Optional[Set[date]]:
+        if self._cn_trading_calendar is not None:
+            return {value for value in self._cn_trading_calendar if start <= value <= end}
+        if self._cn_trading_calendar_unavailable:
+            return None
+
+        try:
+            from app.data_collectors.scheduler import _get_cn_trading_dates
+
+            calendar_end = max(end, date.today())
+            self._cn_trading_calendar = set(_get_cn_trading_dates(date(1990, 1, 1), calendar_end))
+        except Exception:
+            self._cn_trading_calendar_unavailable = True
+            return None
+
+        return {value for value in self._cn_trading_calendar if start <= value <= end}
 
     async def _get_record(self, db: AsyncSession, trade_date: date) -> Optional[DailyAnalysisRecord]:
         result = await db.execute(select(DailyAnalysisRecord).where(DailyAnalysisRecord.trade_date == trade_date))

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -334,6 +334,10 @@ class DailyAnalysisRuleEngine:
         previous = [fact for fact in history if fact.trade_date < today.trade_date]
         if not previous or today.close_price is None:
             return False
+
+        if self._is_ongoing_second_wave(today, previous, trade_dates):
+            return True
+
         major_wave_facts = [
             fact
             for fact in previous
@@ -355,6 +359,44 @@ class DailyAnalysisRuleEngine:
         prior_high = max((fact.high_price or fact.close_price or 0) for fact in previous)
         strong_today = today.is_final_sealed or today.close_price >= prior_high * 0.995
         return strong_today and today.close_price >= prior_high * 0.995
+
+    def _is_ongoing_second_wave(
+        self,
+        today: DailyAnalysisStockFact,
+        previous: List[DailyAnalysisStockFact],
+        trade_dates: List[date],
+    ) -> bool:
+        if not today.is_final_sealed or today.continuous_days < 4:
+            return False
+
+        successes = [
+            fact
+            for fact in [*previous, today]
+            if fact.is_final_sealed
+        ]
+        if len(successes) < 3:
+            return False
+
+        current_wave_start_index = 0
+        for index in range(1, len(successes)):
+            gap = self._trade_gap_days(successes[index - 1].trade_date, successes[index].trade_date, trade_dates)
+            if gap >= 2:
+                current_wave_start_index = index
+
+        if current_wave_start_index == 0:
+            return False
+
+        current_wave = successes[current_wave_start_index:]
+        previous_wave = successes[:current_wave_start_index]
+        if not previous_wave:
+            return False
+
+        break_days = self._trade_gap_days(previous_wave[-1].trade_date, current_wave[0].trade_date, trade_dates)
+        if break_days < 2 or break_days > 8:
+            return False
+
+        current_wave_height = max(fact.continuous_days for fact in current_wave)
+        return current_wave_height >= 4
 
     def _has_long_upper_shadow(self, fact: DailyAnalysisStockFact) -> bool:
         if not fact.high_price or not fact.close_price or not fact.pre_close:

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, time
+import re
 from typing import Any, Dict, Iterable, List, Optional
 
 from sqlalchemy import distinct, select
@@ -53,6 +54,23 @@ class DailyAnalysisStockFact:
 
 class DailyAnalysisRuleEngine:
     """Build daily review signal cells from recent limit-up candidate facts."""
+
+    LOW_SIGNAL_SECTOR_THEMES = {
+        "央企",
+        "央企背景",
+        "国企",
+        "国资",
+        "地方国资",
+        "业绩",
+        "业绩增长",
+        "业绩大增",
+        "一季报增长",
+        "Q1业绩大增",
+        "订单放量",
+        "现金分红",
+        "摘帽",
+        "减亏",
+    }
 
     def build_daily_result(
         self,
@@ -221,8 +239,8 @@ class DailyAnalysisRuleEngine:
     def _build_sector_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
         grouped: Dict[str, List[DailyAnalysisStockFact]] = defaultdict(list)
         for fact in today_facts:
-            sector = fact.reason_category or "其他"
-            grouped[sector].append(fact)
+            for sector in self._sector_themes(fact):
+                grouped[sector].append(fact)
 
         items = []
         for sector, stocks in grouped.items():
@@ -239,7 +257,55 @@ class DailyAnalysisRuleEngine:
                 }
             )
         items.sort(key=lambda item: (-item["score"], item["label"]))
-        return items[:5]
+        return items[:8]
+
+    def _sector_themes(self, fact: DailyAnalysisStockFact) -> List[str]:
+        themes = []
+        for raw_theme in re.split(r"[+＋/／、,，;；|｜]", fact.limit_up_reason or ""):
+            theme = self._normalize_sector_theme(raw_theme)
+            if not theme or theme in themes:
+                continue
+            if theme in self.LOW_SIGNAL_SECTOR_THEMES:
+                continue
+            themes.append(theme)
+            if len(themes) >= 2:
+                break
+
+        if themes:
+            return themes
+        return [fact.reason_category or "其他"]
+
+    def _normalize_sector_theme(self, raw_theme: str) -> str:
+        theme = re.sub(r"\s+", "", raw_theme or "")
+        theme = theme.strip("：:（）()[]【】")
+        if not theme:
+            return ""
+        theme = re.sub(r"概念$", "", theme)
+        theme = re.sub(r"(板块|方向|业务)$", "", theme)
+        theme = theme.replace("AI算力", "算力")
+        if "人形机器人" in theme:
+            return "人形机器人"
+        if "光模块" in theme:
+            return "光模块"
+        if "Token工厂" in theme or "token工厂" in theme:
+            return "Token工厂"
+        if "算力租赁" in theme:
+            return "算力租赁"
+        if "数据中心" in theme:
+            return "数据中心"
+        if "固态电池" in theme:
+            return "固态电池"
+        if "储能" in theme:
+            return "储能"
+        if "液冷" in theme:
+            return "液冷"
+        if "商业航天" in theme:
+            return "商业航天"
+        if "房地产" in theme:
+            return "房地产"
+        if len(theme) > 12:
+            return ""
+        return theme
 
     def _build_negative_feedback_items(
         self,

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -189,20 +189,25 @@ class DailyAnalysisRuleEngine:
         trade_dates: List[date],
     ) -> List[Dict[str, Any]]:
         items = []
+        twenty_cm_height_counts = Counter(
+            max(fact.continuous_days, 1)
+            for fact in today_facts
+            if fact.is_20cm and fact.is_final_sealed and max(fact.continuous_days, 1) >= 2
+        )
         for fact in today_facts:
             if not fact.is_20cm:
                 continue
             stock_history = history.get(fact.stock_code, [])
             tags = []
-            if fact.continuous_days >= 2:
-                tags.append("连板")
+            height = max(fact.continuous_days, 1)
+            if fact.is_final_sealed and height >= 2 and twenty_cm_height_counts.get(height) == 1:
+                tags.extend(["唯一高度", f"{height}板"])
             if self._has_long_upper_shadow(fact):
                 tags.append("长上影")
-            if self._is_trend(fact, stock_history):
-                tags.append("趋势")
-            if self._is_rebound(fact, stock_history, trade_dates):
-                tags.append("反包")
-            items.append(self._stock_item(fact, tags=tags or ["20cm"], score=self._recognition_score(fact)))
+            if self._is_recent_20cm_limit_new_high(fact, stock_history, trade_dates):
+                tags.append("5日涨停新高")
+            if tags:
+                items.append(self._stock_item(fact, tags=tags, score=self._recognition_score(fact)))
         return self._sort_items(items)
 
     def _build_one_word_arbitrage_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
@@ -409,6 +414,31 @@ class DailyAnalysisRuleEngine:
         high_gain_pct = (fact.high_price - fact.pre_close) / fact.pre_close * 100
         upper_shadow_pct = (fact.high_price - fact.close_price) / fact.pre_close * 100
         return high_gain_pct >= 12 and upper_shadow_pct >= 5 and fact.close_price <= fact.high_price * 0.94
+
+    def _is_recent_20cm_limit_new_high(
+        self,
+        today: DailyAnalysisStockFact,
+        history: List[DailyAnalysisStockFact],
+        trade_dates: List[date],
+    ) -> bool:
+        if not today.is_20cm or not today.is_final_sealed or today.close_price is None:
+            return False
+
+        previous_dates = [value for value in trade_dates if value < today.trade_date]
+        recent_dates = set(previous_dates[-5:])
+        if not recent_dates:
+            return False
+
+        recent_previous = [
+            fact
+            for fact in history
+            if fact.trade_date in recent_dates and fact.trade_date < today.trade_date
+        ]
+        if not any(fact.is_final_sealed for fact in recent_previous):
+            return False
+
+        prior_high = max((fact.high_price or fact.close_price or 0) for fact in recent_previous)
+        return prior_high > 0 and today.close_price > prior_high
 
     def _is_one_word_arbitrage(self, fact: DailyAnalysisStockFact) -> bool:
         clock = self._clock(fact.first_limit_time)

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -62,11 +62,12 @@ class DailyAnalysisRuleEngine:
         all_facts = sorted(facts, key=lambda fact: (fact.trade_date, fact.stock_code))
         history = self._group_history(all_facts)
         today_facts = [fact for fact in all_facts if fact.trade_date == trade_date]
+        previous_trade_date = self._previous_trade_date(trade_date, all_facts)
 
         result = {column: self._cell([]) for column in SIGNAL_COLUMNS}
         result["连板唯一性"] = self._cell(self._build_unique_board_items(today_facts))
         result["反包+趋势+弹钢琴"] = self._cell(self._build_combined_pattern_items(trade_date, today_facts, history))
-        result["炸板反包"] = self._cell(self._build_broken_rebound_items(trade_date, today_facts, history))
+        result["炸板反包"] = self._cell(self._build_broken_rebound_items(trade_date, today_facts, history, previous_trade_date))
         result["辨识度"] = self._cell(self._build_recognition_items(today_facts))
         result["二波"] = self._cell(self._build_second_wave_items(trade_date, today_facts, history))
         result["20cm"] = self._cell(self._build_20cm_items(trade_date, today_facts, history))
@@ -86,6 +87,14 @@ class DailyAnalysisRuleEngine:
             values.sort(key=lambda fact: fact.trade_date)
         return grouped
 
+    def _previous_trade_date(
+        self,
+        trade_date: date,
+        facts: Iterable[DailyAnalysisStockFact],
+    ) -> Optional[date]:
+        trade_dates = sorted({fact.trade_date for fact in facts if fact.trade_date < trade_date})
+        return trade_dates[-1] if trade_dates else None
+
     def _build_unique_board_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
         if not today_facts:
             return []
@@ -103,28 +112,36 @@ class DailyAnalysisRuleEngine:
     ) -> List[Dict[str, Any]]:
         items = []
         for fact in today_facts:
-            tags = []
             stock_history = history.get(fact.stock_code, [])
-            if self._is_rebound(fact, stock_history):
-                tags.append("反包")
-            if self._is_trend(fact, stock_history):
-                tags.append("趋势")
-            if self._is_piano(fact, stock_history):
-                tags.append("弹钢琴")
-            if tags:
-                items.append(self._stock_item(fact, tags=tags, score=self._recognition_score(fact)))
+            tag = self._combined_pattern_tag(fact, stock_history)
+            if tag:
+                items.append(self._stock_item(fact, tags=[tag], score=self._recognition_score(fact)))
         return self._sort_items(items)
+
+    def _combined_pattern_tag(
+        self,
+        fact: DailyAnalysisStockFact,
+        stock_history: List[DailyAnalysisStockFact],
+    ) -> Optional[str]:
+        if self._is_piano(fact, stock_history):
+            return "弹钢琴"
+        if self._is_rebound(fact, stock_history):
+            return "反包"
+        if self._is_trend(fact, stock_history):
+            return "趋势"
+        return None
 
     def _build_broken_rebound_items(
         self,
         trade_date: date,
         today_facts: List[DailyAnalysisStockFact],
         history: Dict[str, List[DailyAnalysisStockFact]],
+        previous_trade_date: Optional[date],
     ) -> List[Dict[str, Any]]:
         items = [
             self._stock_item(fact, tags=["炸板反包"], score=self._recognition_score(fact))
             for fact in today_facts
-            if self._is_broken_rebound(fact, history.get(fact.stock_code, []))
+            if self._is_broken_rebound(fact, history.get(fact.stock_code, []), previous_trade_date)
         ]
         return self._sort_items(items)
 
@@ -220,10 +237,15 @@ class DailyAnalysisRuleEngine:
 
     def _is_rebound(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
         previous = [fact for fact in history if fact.trade_date < today.trade_date]
-        if not previous or today.close_price is None:
+        if not previous or today.close_price is None or not today.is_final_sealed:
+            return False
+        if max(today.continuous_days, 1) != 1:
             return False
 
         recent = previous[-3:]
+        prior_success = [fact for fact in previous if fact.is_final_sealed]
+        if not prior_success:
+            return False
         prior_high = max((fact.high_price or fact.close_price or 0) for fact in recent)
         had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in recent)
         return had_disagreement and prior_high > 0 and today.close_price >= prior_high * 0.995
@@ -240,16 +262,32 @@ class DailyAnalysisRuleEngine:
         recent = [fact for fact in history if fact.trade_date <= today.trade_date]
         if len(recent) < 3:
             return False
-        had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in recent[:-1])
+        previous = recent[:-1]
+        prior_success_count = sum(1 for fact in previous if fact.is_final_sealed)
+        if prior_success_count < 2:
+            return False
+        had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in previous)
         strong_today = today.is_final_sealed or (today.change_pct is not None and today.change_pct >= 6)
         return had_disagreement and strong_today
 
-    def _is_broken_rebound(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+    def _is_broken_rebound(
+        self,
+        today: DailyAnalysisStockFact,
+        history: List[DailyAnalysisStockFact],
+        previous_trade_date: Optional[date],
+    ) -> bool:
         previous = [fact for fact in history if fact.trade_date < today.trade_date]
-        if not previous:
+        if not previous or previous_trade_date is None:
             return False
-        recent = previous[-3:]
-        broken = [fact for fact in recent if (not fact.is_final_sealed) or fact.open_count > 0]
+        if max(today.continuous_days, 1) != 1:
+            return False
+        if any(fact.is_final_sealed for fact in previous):
+            return False
+        broken = [
+            fact
+            for fact in previous
+            if fact.trade_date == previous_trade_date and ((not fact.is_final_sealed) or fact.open_count > 0)
+        ]
         if not broken:
             return False
         broken_high = max((fact.high_price or fact.close_price or 0) for fact in broken)

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -62,15 +62,16 @@ class DailyAnalysisRuleEngine:
         all_facts = sorted(facts, key=lambda fact: (fact.trade_date, fact.stock_code))
         history = self._group_history(all_facts)
         today_facts = [fact for fact in all_facts if fact.trade_date == trade_date]
-        previous_trade_date = self._previous_trade_date(trade_date, all_facts)
+        trade_dates = sorted({fact.trade_date for fact in all_facts})
+        previous_trade_date = self._previous_trade_date(trade_date, trade_dates)
 
         result = {column: self._cell([]) for column in SIGNAL_COLUMNS}
         result["连板唯一性"] = self._cell(self._build_unique_board_items(today_facts))
-        result["反包+趋势+弹钢琴"] = self._cell(self._build_combined_pattern_items(trade_date, today_facts, history))
+        result["反包+趋势+弹钢琴"] = self._cell(self._build_combined_pattern_items(trade_date, today_facts, history, trade_dates))
         result["炸板反包"] = self._cell(self._build_broken_rebound_items(trade_date, today_facts, history, previous_trade_date))
         result["辨识度"] = self._cell(self._build_recognition_items(today_facts))
-        result["二波"] = self._cell(self._build_second_wave_items(trade_date, today_facts, history))
-        result["20cm"] = self._cell(self._build_20cm_items(trade_date, today_facts, history))
+        result["二波"] = self._cell(self._build_second_wave_items(trade_date, today_facts, history, trade_dates))
+        result["20cm"] = self._cell(self._build_20cm_items(trade_date, today_facts, history, trade_dates))
         result["一字套利"] = self._cell(self._build_one_word_arbitrage_items(today_facts))
         result["板块"] = self._cell(self._build_sector_items(today_facts))
         result["负反馈"] = self._cell(self._build_negative_feedback_items(trade_date, today_facts, history))
@@ -90,10 +91,18 @@ class DailyAnalysisRuleEngine:
     def _previous_trade_date(
         self,
         trade_date: date,
-        facts: Iterable[DailyAnalysisStockFact],
+        trade_dates: Iterable[date],
     ) -> Optional[date]:
-        trade_dates = sorted({fact.trade_date for fact in facts if fact.trade_date < trade_date})
-        return trade_dates[-1] if trade_dates else None
+        previous_dates = [value for value in trade_dates if value < trade_date]
+        return previous_dates[-1] if previous_dates else None
+
+    def _trade_gap_days(
+        self,
+        start_date: date,
+        end_date: date,
+        trade_dates: Iterable[date],
+    ) -> int:
+        return sum(1 for value in trade_dates if start_date < value < end_date)
 
     def _build_unique_board_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
         if not today_facts:
@@ -109,11 +118,12 @@ class DailyAnalysisRuleEngine:
         trade_date: date,
         today_facts: List[DailyAnalysisStockFact],
         history: Dict[str, List[DailyAnalysisStockFact]],
+        trade_dates: List[date],
     ) -> List[Dict[str, Any]]:
         items = []
         for fact in today_facts:
             stock_history = history.get(fact.stock_code, [])
-            tag = self._combined_pattern_tag(fact, stock_history)
+            tag = self._combined_pattern_tag(fact, stock_history, trade_dates)
             if tag:
                 items.append(self._stock_item(fact, tags=[tag], score=self._recognition_score(fact)))
         return self._sort_items(items)
@@ -122,10 +132,11 @@ class DailyAnalysisRuleEngine:
         self,
         fact: DailyAnalysisStockFact,
         stock_history: List[DailyAnalysisStockFact],
+        trade_dates: List[date],
     ) -> Optional[str]:
         if self._is_piano(fact, stock_history):
             return "弹钢琴"
-        if self._is_rebound(fact, stock_history):
+        if self._is_rebound(fact, stock_history, trade_dates):
             return "反包"
         if self._is_trend(fact, stock_history):
             return "趋势"
@@ -161,11 +172,12 @@ class DailyAnalysisRuleEngine:
         trade_date: date,
         today_facts: List[DailyAnalysisStockFact],
         history: Dict[str, List[DailyAnalysisStockFact]],
+        trade_dates: List[date],
     ) -> List[Dict[str, Any]]:
         items = [
             self._stock_item(fact, tags=["二波"], score=self._recognition_score(fact))
             for fact in today_facts
-            if self._is_second_wave(fact, history.get(fact.stock_code, []))
+            if self._is_second_wave(fact, history.get(fact.stock_code, []), trade_dates)
         ]
         return self._sort_items(items)
 
@@ -174,6 +186,7 @@ class DailyAnalysisRuleEngine:
         trade_date: date,
         today_facts: List[DailyAnalysisStockFact],
         history: Dict[str, List[DailyAnalysisStockFact]],
+        trade_dates: List[date],
     ) -> List[Dict[str, Any]]:
         items = []
         for fact in today_facts:
@@ -187,7 +200,7 @@ class DailyAnalysisRuleEngine:
                 tags.append("长上影")
             if self._is_trend(fact, stock_history):
                 tags.append("趋势")
-            if self._is_rebound(fact, stock_history):
+            if self._is_rebound(fact, stock_history, trade_dates):
                 tags.append("反包")
             items.append(self._stock_item(fact, tags=tags or ["20cm"], score=self._recognition_score(fact)))
         return self._sort_items(items)
@@ -235,20 +248,37 @@ class DailyAnalysisRuleEngine:
                 items.append(self._stock_item(fact, tags=["负反馈"], score=self._recognition_score(fact)))
         return self._sort_items(items)
 
-    def _is_rebound(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+    def _is_rebound(
+        self,
+        today: DailyAnalysisStockFact,
+        history: List[DailyAnalysisStockFact],
+        trade_dates: List[date],
+    ) -> bool:
         previous = [fact for fact in history if fact.trade_date < today.trade_date]
         if not previous or today.close_price is None or not today.is_final_sealed:
             return False
         if max(today.continuous_days, 1) != 1:
             return False
 
-        recent = previous[-3:]
         prior_success = [fact for fact in previous if fact.is_final_sealed]
         if not prior_success:
             return False
-        prior_high = max((fact.high_price or fact.close_price or 0) for fact in recent)
-        had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in recent)
-        return had_disagreement and prior_high > 0 and today.close_price >= prior_high * 0.995
+
+        last_success = prior_success[-1]
+        break_days = self._trade_gap_days(last_success.trade_date, today.trade_date, trade_dates)
+        if break_days != 1:
+            return False
+
+        between_facts = [
+            fact
+            for fact in previous
+            if last_success.trade_date <= fact.trade_date < today.trade_date
+        ]
+        if any(fact.trade_date > last_success.trade_date and fact.is_final_sealed for fact in between_facts):
+            return False
+
+        prior_high = max((fact.high_price or fact.close_price or 0) for fact in between_facts)
+        return prior_high > 0 and today.close_price >= prior_high * 0.995
 
     def _is_trend(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
         recent = [fact for fact in history if fact.trade_date <= today.trade_date and fact.close_price is not None][-4:]
@@ -295,18 +325,36 @@ class DailyAnalysisRuleEngine:
         broken_high = max((fact.high_price or fact.close_price or 0) for fact in broken)
         return today.is_final_sealed and today.close_price is not None and today.close_price >= broken_high * 0.995
 
-    def _is_second_wave(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+    def _is_second_wave(
+        self,
+        today: DailyAnalysisStockFact,
+        history: List[DailyAnalysisStockFact],
+        trade_dates: List[date],
+    ) -> bool:
         previous = [fact for fact in history if fact.trade_date < today.trade_date]
-        if len(previous) < 2 or today.close_price is None:
+        if not previous or today.close_price is None:
             return False
-        had_first_wave = any(fact.continuous_days >= 2 for fact in previous) or len(previous) >= 2
-        prior_high = max((fact.high_price or fact.close_price or 0) for fact in previous)
-        had_pullback = any(
-            (not fact.is_final_sealed)
-            or ((fact.close_price or 0) < (fact.high_price or fact.close_price or 0) * 0.98)
+        major_wave_facts = [
+            fact
             for fact in previous
-        )
-        return had_first_wave and had_pullback and today.close_price >= prior_high * 0.995
+            if fact.is_final_sealed and fact.continuous_days >= 4
+        ]
+        if not major_wave_facts:
+            return False
+
+        first_wave_high = major_wave_facts[-1]
+        break_days = self._trade_gap_days(first_wave_high.trade_date, today.trade_date, trade_dates)
+        if break_days < 2 or break_days > 8:
+            return False
+        if any(
+            fact.trade_date > first_wave_high.trade_date and fact.is_final_sealed
+            for fact in previous
+        ):
+            return False
+
+        prior_high = max((fact.high_price or fact.close_price or 0) for fact in previous)
+        strong_today = today.is_final_sealed or today.close_price >= prior_high * 0.995
+        return strong_today and today.close_price >= prior_high * 0.995
 
     def _has_long_upper_shadow(self, fact: DailyAnalysisStockFact) -> bool:
         if not fact.high_price or not fact.close_price or not fact.pre_close:

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -10,7 +10,7 @@ from sqlalchemy import distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.limit_up import LimitUpRecord
-from app.models.market_review import DailyAnalysisRecord
+from app.models.market_review import DailyAnalysisRecord, MarketReviewStockDaily
 from app.models.stock import Stock
 
 
@@ -76,10 +76,16 @@ class DailyAnalysisRuleEngine:
         self,
         trade_date: date,
         facts: Iterable[DailyAnalysisStockFact],
+        negative_feedback_facts: Optional[Iterable[DailyAnalysisStockFact]] = None,
     ) -> Dict[str, Dict[str, Any]]:
         all_facts = sorted(facts, key=lambda fact: (fact.trade_date, fact.stock_code))
         history = self._group_history(all_facts)
         today_facts = [fact for fact in all_facts if fact.trade_date == trade_date]
+        negative_today_facts = (
+            [fact for fact in negative_feedback_facts if fact.trade_date == trade_date]
+            if negative_feedback_facts is not None
+            else today_facts
+        )
         trade_dates = sorted({fact.trade_date for fact in all_facts})
         previous_trade_date = self._previous_trade_date(trade_date, trade_dates)
 
@@ -92,7 +98,7 @@ class DailyAnalysisRuleEngine:
         result["20cm"] = self._cell(self._build_20cm_items(trade_date, today_facts, history, trade_dates))
         result["一字套利"] = self._cell(self._build_one_word_arbitrage_items(today_facts))
         result["板块"] = self._cell(self._build_sector_items(today_facts))
-        result["负反馈"] = self._cell(self._build_negative_feedback_items(trade_date, today_facts, history))
+        result["负反馈"] = self._cell(self._build_negative_feedback_items(trade_date, negative_today_facts, history))
         return result
 
     def _group_history(
@@ -316,7 +322,13 @@ class DailyAnalysisRuleEngine:
         items = []
         for fact in today_facts:
             if self._is_negative_feedback(fact, history.get(fact.stock_code, [])):
-                items.append(self._stock_item(fact, tags=["负反馈"], score=self._recognition_score(fact)))
+                items.append(
+                    self._stock_item(
+                        fact,
+                        tags=["跌停"],
+                        score=self._negative_feedback_score(fact, history.get(fact.stock_code, [])),
+                    )
+                )
         return self._sort_items(items)
 
     def _is_rebound(
@@ -530,13 +542,35 @@ class DailyAnalysisRuleEngine:
         if not previous:
             return False
         yesterday = previous[-1]
-        was_core = yesterday.continuous_days >= 2 or self._recognition_score(yesterday) >= 25
-        weak_today = (
-            (not today.is_final_sealed and today.open_count > 0)
-            or (today.change_pct is not None and today.change_pct <= -5)
-            or (today.close_price is not None and today.pre_close is not None and today.close_price <= today.pre_close * 0.95)
-        )
-        return was_core and weak_today
+        return self._is_popular_stock(yesterday) and self._is_limit_down(today)
+
+    def _is_popular_stock(self, fact: DailyAnalysisStockFact) -> bool:
+        return fact.continuous_days >= 2 or self._recognition_score(fact) >= 25
+
+    def _is_limit_down(self, fact: DailyAnalysisStockFact) -> bool:
+        if fact.change_pct is not None:
+            return fact.change_pct <= self._limit_down_change_threshold(fact)
+        if fact.close_price is None or not fact.pre_close:
+            return False
+        ratio = abs(self._limit_down_change_threshold(fact)) / 100
+        return fact.close_price <= fact.pre_close * (1 - ratio) * 1.001
+
+    def _limit_down_change_threshold(self, fact: DailyAnalysisStockFact) -> float:
+        if "ST" in fact.stock_name.upper():
+            return -4.8
+        if fact.stock_code.startswith(("8", "920")):
+            return -29.5
+        if fact.is_20cm or fact.stock_code.startswith(("300", "301", "688")):
+            return -19.5
+        return -9.5
+
+    def _negative_feedback_score(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> float:
+        previous_scores = [
+            self._recognition_score(fact)
+            for fact in history
+            if fact.trade_date < today.trade_date
+        ]
+        return max(previous_scores or [self._recognition_score(today)])
 
     def _recognition_score(self, fact: DailyAnalysisStockFact) -> float:
         score = fact.continuous_days * 12
@@ -663,7 +697,12 @@ class DailyAnalysisService:
         calc_version: Optional[int] = None,
     ) -> DailyAnalysisRecord:
         facts = await self.collect_candidate_facts(db, trade_date)
-        auto_result = self.rule_engine.build_daily_result(trade_date, facts)
+        negative_feedback_facts = await self.collect_negative_feedback_facts(db, trade_date)
+        auto_result = self.rule_engine.build_daily_result(
+            trade_date,
+            facts,
+            negative_feedback_facts=negative_feedback_facts or None,
+        )
         record = await self._get_record(db, trade_date)
         now = datetime.now()
 
@@ -709,6 +748,21 @@ class DailyAnalysisService:
         result = await db.execute(query)
         rows = result.all()
         return [self._to_fact(record, stock) for record, stock in rows]
+
+    async def collect_negative_feedback_facts(
+        self,
+        db: AsyncSession,
+        trade_date: date,
+    ) -> List[DailyAnalysisStockFact]:
+        query = (
+            select(MarketReviewStockDaily, Stock)
+            .join(Stock, MarketReviewStockDaily.stock_id == Stock.id)
+            .where(MarketReviewStockDaily.trade_date == trade_date)
+            .order_by(MarketReviewStockDaily.stock_code)
+        )
+        result = await db.execute(query)
+        rows = result.all()
+        return [self._to_fact_from_review_stock(row, stock) for row, stock in rows]
 
     def serialize_record(self, record: DailyAnalysisRecord) -> Dict[str, Any]:
         auto_result = self._normalize_auto_result(record.auto_result or {})
@@ -808,6 +862,40 @@ class DailyAnalysisService:
             amount=float(record.amount or 0),
             turnover_rate=self._to_float(record.turnover_rate),
         )
+
+    def _to_fact_from_review_stock(self, row: MarketReviewStockDaily, stock: Stock) -> DailyAnalysisStockFact:
+        is_20cm = bool(
+            stock.is_cy
+            or stock.is_kc
+            or row.board_type in {"gem", "star"}
+            or row.stock_code.startswith(("300", "301", "688"))
+        )
+        return DailyAnalysisStockFact(
+            trade_date=row.trade_date,
+            stock_code=row.stock_code,
+            stock_name=row.stock_name,
+            reason_category=stock.industry or "其他",
+            limit_up_reason=row.limit_up_reason or stock.industry or "",
+            continuous_days=int(row.today_continuous_days or 0),
+            open_count=int(row.open_count or 0),
+            is_final_sealed=bool(row.today_sealed_close),
+            is_20cm=is_20cm,
+            first_limit_time=self._combine_date_time(row.trade_date, row.first_limit_time),
+            final_seal_time=self._combine_date_time(row.trade_date, row.final_seal_time),
+            open_price=None,
+            close_price=self._to_float(row.close_price),
+            high_price=self._to_float(row.close_price),
+            low_price=self._to_float(row.close_price),
+            pre_close=self._to_float(row.pre_close),
+            change_pct=self._to_float(row.change_pct),
+            amount=float(row.amount or 0),
+            turnover_rate=self._to_float(row.turnover_rate),
+        )
+
+    def _combine_date_time(self, trade_date: date, value: Optional[time]) -> Optional[datetime]:
+        if value is None:
+            return None
+        return datetime.combine(trade_date, value)
 
     def _estimate_pre_close(
         self,

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -202,9 +202,9 @@ class DailyAnalysisRuleEngine:
             height = max(fact.continuous_days, 1)
             if fact.is_final_sealed and height >= 2 and twenty_cm_height_counts.get(height) == 1:
                 tags.extend(["唯一高度", f"{height}板"])
-            if self._has_long_upper_shadow(fact):
+            elif self._has_long_upper_shadow(fact):
                 tags.append("长上影")
-            if self._is_recent_20cm_limit_new_high(fact, stock_history, trade_dates):
+            elif self._is_recent_20cm_limit_new_high(fact, stock_history, trade_dates):
                 tags.append("5日涨停新高")
             if tags:
                 items.append(self._stock_item(fact, tags=tags, score=self._recognition_score(fact)))

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -259,6 +259,8 @@ class DailyAnalysisRuleEngine:
         return rising_steps >= 3 and closes[-1] > closes[0] * 1.08
 
     def _is_piano(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        if max(today.continuous_days, 1) != 1:
+            return False
         recent = [fact for fact in history if fact.trade_date <= today.trade_date]
         if len(recent) < 3:
             return False

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from typing import Any, Dict, Iterable, List, Optional
+
+from sqlalchemy import distinct, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.limit_up import LimitUpRecord
+from app.models.market_review import DailyAnalysisRecord
+from app.models.stock import Stock
+
+
+DAILY_ANALYSIS_COLUMNS = [
+    "时间",
+    "连板唯一性",
+    "反包+趋势+弹钢琴",
+    "炸板反包",
+    "辨识度",
+    "二波",
+    "20cm",
+    "一字套利",
+    "板块",
+    "负反馈",
+]
+SIGNAL_COLUMNS = DAILY_ANALYSIS_COLUMNS[1:]
+
+
+@dataclass(frozen=True)
+class DailyAnalysisStockFact:
+    trade_date: date
+    stock_code: str
+    stock_name: str
+    reason_category: str
+    limit_up_reason: str
+    continuous_days: int
+    open_count: int
+    is_final_sealed: bool
+    is_20cm: bool
+    first_limit_time: Optional[datetime]
+    final_seal_time: Optional[datetime]
+    open_price: Optional[float]
+    close_price: Optional[float]
+    high_price: Optional[float]
+    low_price: Optional[float]
+    pre_close: Optional[float]
+    change_pct: Optional[float]
+    amount: float
+    turnover_rate: Optional[float]
+
+
+class DailyAnalysisRuleEngine:
+    """Build daily review signal cells from recent limit-up candidate facts."""
+
+    def build_daily_result(
+        self,
+        trade_date: date,
+        facts: Iterable[DailyAnalysisStockFact],
+    ) -> Dict[str, Dict[str, Any]]:
+        all_facts = sorted(facts, key=lambda fact: (fact.trade_date, fact.stock_code))
+        history = self._group_history(all_facts)
+        today_facts = [fact for fact in all_facts if fact.trade_date == trade_date]
+
+        result = {column: self._cell([]) for column in SIGNAL_COLUMNS}
+        result["连板唯一性"] = self._cell(self._build_unique_board_items(today_facts))
+        result["反包+趋势+弹钢琴"] = self._cell(self._build_combined_pattern_items(trade_date, today_facts, history))
+        result["炸板反包"] = self._cell(self._build_broken_rebound_items(trade_date, today_facts, history))
+        result["辨识度"] = self._cell(self._build_recognition_items(today_facts))
+        result["二波"] = self._cell(self._build_second_wave_items(trade_date, today_facts, history))
+        result["20cm"] = self._cell(self._build_20cm_items(trade_date, today_facts, history))
+        result["一字套利"] = self._cell(self._build_one_word_arbitrage_items(today_facts))
+        result["板块"] = self._cell(self._build_sector_items(today_facts))
+        result["负反馈"] = self._cell(self._build_negative_feedback_items(trade_date, today_facts, history))
+        return result
+
+    def _group_history(
+        self,
+        facts: Iterable[DailyAnalysisStockFact],
+    ) -> Dict[str, List[DailyAnalysisStockFact]]:
+        grouped: Dict[str, List[DailyAnalysisStockFact]] = defaultdict(list)
+        for fact in facts:
+            grouped[fact.stock_code].append(fact)
+        for values in grouped.values():
+            values.sort(key=lambda fact: fact.trade_date)
+        return grouped
+
+    def _build_unique_board_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
+        if not today_facts:
+            return []
+
+        max_height = max(max(fact.continuous_days, 1) for fact in today_facts)
+        top_facts = [fact for fact in today_facts if max(fact.continuous_days, 1) == max_height]
+        tags = ["唯一", f"{max_height}板"] if len(top_facts) == 1 else ["竞争", f"{max_height}板"]
+        return [self._stock_item(fact, tags=tags, score=self._recognition_score(fact)) for fact in top_facts]
+
+    def _build_combined_pattern_items(
+        self,
+        trade_date: date,
+        today_facts: List[DailyAnalysisStockFact],
+        history: Dict[str, List[DailyAnalysisStockFact]],
+    ) -> List[Dict[str, Any]]:
+        items = []
+        for fact in today_facts:
+            tags = []
+            stock_history = history.get(fact.stock_code, [])
+            if self._is_rebound(fact, stock_history):
+                tags.append("反包")
+            if self._is_trend(fact, stock_history):
+                tags.append("趋势")
+            if self._is_piano(fact, stock_history):
+                tags.append("弹钢琴")
+            if tags:
+                items.append(self._stock_item(fact, tags=tags, score=self._recognition_score(fact)))
+        return self._sort_items(items)
+
+    def _build_broken_rebound_items(
+        self,
+        trade_date: date,
+        today_facts: List[DailyAnalysisStockFact],
+        history: Dict[str, List[DailyAnalysisStockFact]],
+    ) -> List[Dict[str, Any]]:
+        items = [
+            self._stock_item(fact, tags=["炸板反包"], score=self._recognition_score(fact))
+            for fact in today_facts
+            if self._is_broken_rebound(fact, history.get(fact.stock_code, []))
+        ]
+        return self._sort_items(items)
+
+    def _build_recognition_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
+        scored = [
+            self._stock_item(
+                fact,
+                tags=self._recognition_tags(fact),
+                score=self._recognition_score(fact),
+            )
+            for fact in today_facts
+        ]
+        return self._sort_items(scored)[:5]
+
+    def _build_second_wave_items(
+        self,
+        trade_date: date,
+        today_facts: List[DailyAnalysisStockFact],
+        history: Dict[str, List[DailyAnalysisStockFact]],
+    ) -> List[Dict[str, Any]]:
+        items = [
+            self._stock_item(fact, tags=["二波"], score=self._recognition_score(fact))
+            for fact in today_facts
+            if self._is_second_wave(fact, history.get(fact.stock_code, []))
+        ]
+        return self._sort_items(items)
+
+    def _build_20cm_items(
+        self,
+        trade_date: date,
+        today_facts: List[DailyAnalysisStockFact],
+        history: Dict[str, List[DailyAnalysisStockFact]],
+    ) -> List[Dict[str, Any]]:
+        items = []
+        for fact in today_facts:
+            if not fact.is_20cm:
+                continue
+            stock_history = history.get(fact.stock_code, [])
+            tags = []
+            if fact.continuous_days >= 2:
+                tags.append("连板")
+            if self._has_long_upper_shadow(fact):
+                tags.append("长上影")
+            if self._is_trend(fact, stock_history):
+                tags.append("趋势")
+            if self._is_rebound(fact, stock_history):
+                tags.append("反包")
+            items.append(self._stock_item(fact, tags=tags or ["20cm"], score=self._recognition_score(fact)))
+        return self._sort_items(items)
+
+    def _build_one_word_arbitrage_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
+        items = [
+            self._stock_item(fact, tags=["一字"], score=self._recognition_score(fact))
+            for fact in today_facts
+            if self._is_one_word_arbitrage(fact)
+        ]
+        return self._sort_items(items)
+
+    def _build_sector_items(self, today_facts: List[DailyAnalysisStockFact]) -> List[Dict[str, Any]]:
+        grouped: Dict[str, List[DailyAnalysisStockFact]] = defaultdict(list)
+        for fact in today_facts:
+            sector = fact.reason_category or "其他"
+            grouped[sector].append(fact)
+
+        items = []
+        for sector, stocks in grouped.items():
+            stocks.sort(key=lambda fact: self._recognition_score(fact), reverse=True)
+            continuous_count = sum(1 for fact in stocks if fact.continuous_days >= 2)
+            twenty_count = sum(1 for fact in stocks if fact.is_20cm)
+            score = len(stocks) * 10 + continuous_count * 4 + twenty_count * 3
+            items.append(
+                {
+                    "label": sector,
+                    "tags": [f"{len(stocks)}只", f"连板{continuous_count}只", f"20cm{twenty_count}只"],
+                    "content": "、".join(f"{fact.stock_name}({fact.stock_code})" for fact in stocks[:5]),
+                    "score": score,
+                }
+            )
+        items.sort(key=lambda item: (-item["score"], item["label"]))
+        return items[:5]
+
+    def _build_negative_feedback_items(
+        self,
+        trade_date: date,
+        today_facts: List[DailyAnalysisStockFact],
+        history: Dict[str, List[DailyAnalysisStockFact]],
+    ) -> List[Dict[str, Any]]:
+        items = []
+        for fact in today_facts:
+            if self._is_negative_feedback(fact, history.get(fact.stock_code, [])):
+                items.append(self._stock_item(fact, tags=["负反馈"], score=self._recognition_score(fact)))
+        return self._sort_items(items)
+
+    def _is_rebound(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        previous = [fact for fact in history if fact.trade_date < today.trade_date]
+        if not previous or today.close_price is None:
+            return False
+
+        recent = previous[-3:]
+        prior_high = max((fact.high_price or fact.close_price or 0) for fact in recent)
+        had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in recent)
+        return had_disagreement and prior_high > 0 and today.close_price >= prior_high * 0.995
+
+    def _is_trend(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        recent = [fact for fact in history if fact.trade_date <= today.trade_date and fact.close_price is not None][-4:]
+        if len(recent) < 4:
+            return False
+        closes = [float(fact.close_price or 0) for fact in recent]
+        rising_steps = sum(1 for prev, curr in zip(closes, closes[1:]) if curr >= prev * 0.995)
+        return rising_steps >= 3 and closes[-1] > closes[0] * 1.08
+
+    def _is_piano(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        recent = [fact for fact in history if fact.trade_date <= today.trade_date]
+        if len(recent) < 3:
+            return False
+        had_disagreement = any((not fact.is_final_sealed) or fact.open_count > 0 for fact in recent[:-1])
+        strong_today = today.is_final_sealed or (today.change_pct is not None and today.change_pct >= 6)
+        return had_disagreement and strong_today
+
+    def _is_broken_rebound(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        previous = [fact for fact in history if fact.trade_date < today.trade_date]
+        if not previous:
+            return False
+        recent = previous[-3:]
+        broken = [fact for fact in recent if (not fact.is_final_sealed) or fact.open_count > 0]
+        if not broken:
+            return False
+        broken_high = max((fact.high_price or fact.close_price or 0) for fact in broken)
+        return today.is_final_sealed and today.close_price is not None and today.close_price >= broken_high * 0.995
+
+    def _is_second_wave(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        previous = [fact for fact in history if fact.trade_date < today.trade_date]
+        if len(previous) < 2 or today.close_price is None:
+            return False
+        had_first_wave = any(fact.continuous_days >= 2 for fact in previous) or len(previous) >= 2
+        prior_high = max((fact.high_price or fact.close_price or 0) for fact in previous)
+        had_pullback = any(
+            (not fact.is_final_sealed)
+            or ((fact.close_price or 0) < (fact.high_price or fact.close_price or 0) * 0.98)
+            for fact in previous
+        )
+        return had_first_wave and had_pullback and today.close_price >= prior_high * 0.995
+
+    def _has_long_upper_shadow(self, fact: DailyAnalysisStockFact) -> bool:
+        if not fact.high_price or not fact.close_price or not fact.pre_close:
+            return False
+        high_gain_pct = (fact.high_price - fact.pre_close) / fact.pre_close * 100
+        upper_shadow_pct = (fact.high_price - fact.close_price) / fact.pre_close * 100
+        return high_gain_pct >= 12 and upper_shadow_pct >= 5 and fact.close_price <= fact.high_price * 0.94
+
+    def _is_one_word_arbitrage(self, fact: DailyAnalysisStockFact) -> bool:
+        clock = self._clock(fact.first_limit_time)
+        if clock is None or clock > time(9, 30, 30) or fact.open_count > 0:
+            return False
+        if not fact.open_price or not fact.low_price or not fact.pre_close:
+            return False
+        limit_ratio = 0.20 if fact.is_20cm else 0.10
+        expected_limit_price = fact.pre_close * (1 + limit_ratio)
+        return fact.open_price >= expected_limit_price * 0.995 and fact.low_price >= expected_limit_price * 0.995
+
+    def _is_negative_feedback(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+        previous = [fact for fact in history if fact.trade_date < today.trade_date]
+        if not previous:
+            return False
+        yesterday = previous[-1]
+        was_core = yesterday.continuous_days >= 2 or self._recognition_score(yesterday) >= 25
+        weak_today = (
+            (not today.is_final_sealed and today.open_count > 0)
+            or (today.change_pct is not None and today.change_pct <= -5)
+            or (today.close_price is not None and today.pre_close is not None and today.close_price <= today.pre_close * 0.95)
+        )
+        return was_core and weak_today
+
+    def _recognition_score(self, fact: DailyAnalysisStockFact) -> float:
+        score = fact.continuous_days * 12
+        if fact.is_final_sealed:
+            score += 8
+        if self._clock(fact.first_limit_time) and self._clock(fact.first_limit_time) <= time(9, 35):
+            score += 6
+        if fact.is_20cm:
+            score += 5
+        score += min((fact.amount or 0) / 10000, 10)
+        score += min((fact.turnover_rate or 0) / 5, 6)
+        score -= min(fact.open_count, 8)
+        return round(score, 2)
+
+    def _recognition_tags(self, fact: DailyAnalysisStockFact) -> List[str]:
+        tags = []
+        if fact.continuous_days >= 2:
+            tags.append(f"{fact.continuous_days}板")
+        if fact.is_20cm:
+            tags.append("20cm")
+        if self._clock(fact.first_limit_time) and self._clock(fact.first_limit_time) <= time(9, 35):
+            tags.append("早盘")
+        if fact.open_count > 0:
+            tags.append(f"开{fact.open_count}")
+        return tags or ["辨识度"]
+
+    def _stock_item(
+        self,
+        fact: DailyAnalysisStockFact,
+        *,
+        tags: List[str],
+        score: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return {
+            "stock_code": fact.stock_code,
+            "stock_name": fact.stock_name,
+            "label": f"{fact.stock_name}({fact.stock_code})",
+            "tags": tags,
+            "reason": fact.limit_up_reason or fact.reason_category or "",
+            "time": self._format_time(fact.first_limit_time),
+            "score": score if score is not None else self._recognition_score(fact),
+        }
+
+    def _cell(self, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {
+            "items": items,
+            "content": self._render_content(items),
+        }
+
+    def _render_content(self, items: List[Dict[str, Any]]) -> str:
+        rendered = []
+        for item in items:
+            label = item.get("label") or item.get("stock_name") or ""
+            tags = item.get("tags") or []
+            rendered.append(f"{label}[{','.join(tags)}]" if tags else label)
+        return "；".join(rendered)
+
+    def _sort_items(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return sorted(items, key=lambda item: (-(item.get("score") or 0), item.get("time") or "23:59:59", item.get("stock_code") or ""))
+
+    def _format_time(self, value: Optional[datetime]) -> Optional[str]:
+        if value is None:
+            return None
+        return value.strftime("%H:%M:%S")
+
+    def _clock(self, value: Optional[datetime]) -> Optional[time]:
+        if value is None:
+            return None
+        return value.time()
+
+
+class DailyAnalysisService:
+    def __init__(self, rule_engine: Optional[DailyAnalysisRuleEngine] = None):
+        self.rule_engine = rule_engine or DailyAnalysisRuleEngine()
+
+    async def get_month(self, db: AsyncSession, month: str) -> Dict[str, Any]:
+        records = await self._get_month_records(db, month)
+        return {
+            "month": month,
+            "data": [self.serialize_record(record) for record in records],
+        }
+
+    async def rebuild_for_date(self, db: AsyncSession, trade_date: date) -> Dict[str, Any]:
+        record = await self.build_for_date(db, trade_date)
+        return self.serialize_record(record)
+
+    async def backfill(self, db: AsyncSession, month: Optional[str] = None) -> Dict[str, Any]:
+        dates = await self._get_trade_dates(db, month)
+        built = []
+        for trade_date in dates:
+            await self.build_for_date(db, trade_date)
+            built.append(trade_date.isoformat())
+        return {"built_count": len(built), "trade_dates": built}
+
+    async def update_overrides(
+        self,
+        db: AsyncSession,
+        trade_date: date,
+        overrides: Dict[str, Optional[str]],
+    ) -> Dict[str, Any]:
+        record = await self._get_record(db, trade_date)
+        if record is None:
+            record = await self.build_for_date(db, trade_date)
+
+        current = dict(record.manual_overrides or {})
+        for column, value in overrides.items():
+            if column not in SIGNAL_COLUMNS:
+                continue
+            if value is None or str(value).strip() == "":
+                current.pop(column, None)
+            else:
+                current[column] = str(value)
+
+        record.manual_overrides = current
+        record.updated_at = datetime.now()
+        await db.commit()
+        await db.refresh(record)
+        return self.serialize_record(record)
+
+    async def build_for_date(
+        self,
+        db: AsyncSession,
+        trade_date: date,
+        calc_version: Optional[int] = None,
+    ) -> DailyAnalysisRecord:
+        facts = await self.collect_candidate_facts(db, trade_date)
+        auto_result = self.rule_engine.build_daily_result(trade_date, facts)
+        record = await self._get_record(db, trade_date)
+        now = datetime.now()
+
+        if record is None:
+            record = DailyAnalysisRecord(
+                trade_date=trade_date,
+                month=trade_date.strftime("%Y-%m"),
+                auto_result=auto_result,
+                manual_overrides={},
+                calc_version=calc_version or 1,
+                data_status="ready",
+                generated_at=now,
+            )
+            db.add(record)
+        else:
+            record.auto_result = auto_result
+            record.month = trade_date.strftime("%Y-%m")
+            record.calc_version = calc_version or (record.calc_version or 0) + 1
+            record.data_status = "ready"
+            record.generated_at = now
+            record.updated_at = now
+
+        await db.commit()
+        await db.refresh(record)
+        return record
+
+    async def collect_candidate_facts(
+        self,
+        db: AsyncSession,
+        trade_date: date,
+        window_size: int = 10,
+    ) -> List[DailyAnalysisStockFact]:
+        dates = await self._get_recent_trade_dates(db, trade_date, window_size)
+        if not dates:
+            return []
+
+        query = (
+            select(LimitUpRecord, Stock)
+            .join(Stock, LimitUpRecord.stock_id == Stock.id)
+            .where(LimitUpRecord.trade_date.in_(dates))
+            .order_by(LimitUpRecord.trade_date, Stock.stock_code)
+        )
+        result = await db.execute(query)
+        rows = result.all()
+        return [self._to_fact(record, stock) for record, stock in rows]
+
+    def serialize_record(self, record: DailyAnalysisRecord) -> Dict[str, Any]:
+        auto_result = self._normalize_auto_result(record.auto_result or {})
+        manual_overrides = dict(record.manual_overrides or {})
+        columns = {}
+        for column in SIGNAL_COLUMNS:
+            auto_cell = dict(auto_result.get(column) or self.rule_engine._cell([]))
+            is_manual = column in manual_overrides
+            if is_manual:
+                auto_cell["content"] = manual_overrides[column]
+            auto_cell["is_manual"] = is_manual
+            columns[column] = auto_cell
+
+        return {
+            "trade_date": record.trade_date.isoformat(),
+            "month": record.month,
+            "status": record.data_status,
+            "calc_version": record.calc_version,
+            "generated_at": record.generated_at.isoformat() if record.generated_at else None,
+            "updated_at": record.updated_at.isoformat() if record.updated_at else None,
+            "auto_result": auto_result,
+            "manual_overrides": manual_overrides,
+            "columns": columns,
+        }
+
+    def _normalize_auto_result(self, raw: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = {}
+        for column in SIGNAL_COLUMNS:
+            cell = dict(raw.get(column) or {})
+            items = cell.get("items") or []
+            cell["items"] = items
+            cell["content"] = cell.get("content") or self.rule_engine._render_content(items)
+            normalized[column] = cell
+        return normalized
+
+    async def _get_recent_trade_dates(self, db: AsyncSession, trade_date: date, limit: int) -> List[date]:
+        query = (
+            select(distinct(LimitUpRecord.trade_date))
+            .where(LimitUpRecord.trade_date <= trade_date)
+            .order_by(LimitUpRecord.trade_date.desc())
+            .limit(limit)
+        )
+        result = await db.execute(query)
+        return sorted([row[0] for row in result.all()])
+
+    async def _get_trade_dates(self, db: AsyncSession, month: Optional[str]) -> List[date]:
+        query = select(distinct(LimitUpRecord.trade_date)).where(LimitUpRecord.trade_date <= date.today())
+        if month:
+            start, end = self._month_bounds(month)
+            query = query.where(LimitUpRecord.trade_date >= start, LimitUpRecord.trade_date <= end)
+        query = query.order_by(LimitUpRecord.trade_date)
+        result = await db.execute(query)
+        return [row[0] for row in result.all()]
+
+    async def _get_month_records(self, db: AsyncSession, month: str) -> List[DailyAnalysisRecord]:
+        query = (
+            select(DailyAnalysisRecord)
+            .where(DailyAnalysisRecord.month == month, DailyAnalysisRecord.trade_date <= date.today())
+            .order_by(DailyAnalysisRecord.trade_date.desc())
+        )
+        result = await db.execute(query)
+        return list(result.scalars().all())
+
+    async def _get_record(self, db: AsyncSession, trade_date: date) -> Optional[DailyAnalysisRecord]:
+        result = await db.execute(select(DailyAnalysisRecord).where(DailyAnalysisRecord.trade_date == trade_date))
+        return result.scalar_one_or_none()
+
+    def _to_fact(self, record: LimitUpRecord, stock: Stock) -> DailyAnalysisStockFact:
+        is_20cm = bool(stock.is_cy or stock.is_kc or stock.stock_code.startswith(("300", "301", "688")))
+        close_price = self._to_float(record.close_price) or self._to_float(record.limit_up_price)
+        open_price = self._to_float(record.open_price) or close_price
+        pre_close = self._estimate_pre_close(record, stock, close_price, is_20cm)
+        high_price = self._estimate_high_price(record, close_price, open_price)
+        low_price = min(value for value in [open_price, close_price, pre_close] if value is not None) if any(value is not None for value in [open_price, close_price, pre_close]) else None
+        change_pct = None
+        if close_price is not None and pre_close:
+            change_pct = round((close_price - pre_close) / pre_close * 100, 2)
+
+        return DailyAnalysisStockFact(
+            trade_date=record.trade_date,
+            stock_code=stock.stock_code,
+            stock_name=stock.stock_name,
+            reason_category=record.reason_category or stock.industry or "其他",
+            limit_up_reason=record.limit_up_reason or record.reason_category or stock.industry or "",
+            continuous_days=int(record.continuous_limit_up_days or 1),
+            open_count=int(record.open_count or 0),
+            is_final_sealed=bool(record.is_final_sealed),
+            is_20cm=is_20cm,
+            first_limit_time=record.first_limit_up_time,
+            final_seal_time=record.final_seal_time,
+            open_price=open_price,
+            close_price=close_price,
+            high_price=high_price,
+            low_price=low_price,
+            pre_close=pre_close,
+            change_pct=change_pct,
+            amount=float(record.amount or 0),
+            turnover_rate=self._to_float(record.turnover_rate),
+        )
+
+    def _estimate_pre_close(
+        self,
+        record: LimitUpRecord,
+        stock: Stock,
+        close_price: Optional[float],
+        is_20cm: bool,
+    ) -> Optional[float]:
+        if record.limit_up_price:
+            ratio = 0.05 if stock.is_st else 0.20 if is_20cm else 0.10
+            return round(float(record.limit_up_price) / (1 + ratio), 4)
+        if close_price and record.current_status == "sealed":
+            ratio = 0.05 if stock.is_st else 0.20 if is_20cm else 0.10
+            return round(close_price / (1 + ratio), 4)
+        return None
+
+    def _estimate_high_price(
+        self,
+        record: LimitUpRecord,
+        close_price: Optional[float],
+        open_price: Optional[float],
+    ) -> Optional[float]:
+        values = [value for value in [close_price, open_price, self._to_float(record.limit_up_price)] if value is not None]
+        if not values:
+            return None
+        if record.amplitude and close_price:
+            return max(max(values), close_price * (1 + min(float(record.amplitude), 30) / 100))
+        return max(values)
+
+    def _month_bounds(self, month: str) -> tuple[date, date]:
+        year, month_num = [int(part) for part in month.split("-")]
+        start = date(year, month_num, 1)
+        if month_num == 12:
+            end = date(year + 1, 1, 1)
+        else:
+            end = date(year, month_num + 1, 1)
+        return start, date.fromordinal(end.toordinal() - 1)
+
+    def _to_float(self, value: Any) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+daily_analysis_service = DailyAnalysisService()

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -138,7 +138,7 @@ class DailyAnalysisRuleEngine:
             return "弹钢琴"
         if self._is_rebound(fact, stock_history, trade_dates):
             return "反包"
-        if self._is_trend(fact, stock_history):
+        if self._is_trend(fact, stock_history, trade_dates):
             return "趋势"
         return None
 
@@ -285,7 +285,16 @@ class DailyAnalysisRuleEngine:
         prior_high = max((fact.high_price or fact.close_price or 0) for fact in between_facts)
         return prior_high > 0 and today.close_price >= prior_high * 0.995
 
-    def _is_trend(self, today: DailyAnalysisStockFact, history: List[DailyAnalysisStockFact]) -> bool:
+    def _is_trend(
+        self,
+        today: DailyAnalysisStockFact,
+        history: List[DailyAnalysisStockFact],
+        trade_dates: Optional[List[date]] = None,
+    ) -> bool:
+        if max(today.continuous_days, 1) >= 2:
+            return False
+        if trade_dates is not None and self._is_second_wave(today, history, trade_dates):
+            return False
         recent = [fact for fact in history if fact.trade_date <= today.trade_date and fact.close_price is not None][-4:]
         if len(recent) < 4:
             return False

--- a/backend/app/services/daily_analysis_service.py
+++ b/backend/app/services/daily_analysis_service.py
@@ -378,10 +378,13 @@ class DailyAnalysisRuleEngine:
             return False
 
         current_wave_start_index = 0
+        current_wave_started_by_height_reset = False
         for index in range(1, len(successes)):
             gap = self._trade_gap_days(successes[index - 1].trade_date, successes[index].trade_date, trade_dates)
-            if gap >= 2:
+            height_reset = successes[index].continuous_days < successes[index - 1].continuous_days
+            if gap >= 2 or height_reset:
                 current_wave_start_index = index
+                current_wave_started_by_height_reset = height_reset
 
         if current_wave_start_index == 0:
             return False
@@ -392,7 +395,9 @@ class DailyAnalysisRuleEngine:
             return False
 
         break_days = self._trade_gap_days(previous_wave[-1].trade_date, current_wave[0].trade_date, trade_dates)
-        if break_days < 2 or break_days > 8:
+        if break_days > 8:
+            return False
+        if break_days < 2 and not current_wave_started_by_height_reset:
             return False
 
         current_wave_height = max(fact.continuous_days for fact in current_wave)

--- a/backend/app/services/market_review_metrics_service.py
+++ b/backend/app/services/market_review_metrics_service.py
@@ -20,12 +20,12 @@ class MarketReviewMetricsService:
         sealed_rows = [row for row in touched_rows if row.get("today_sealed_close")]
         opened_rows = [row for row in touched_rows if row.get("today_opened_close")]
 
-        ladder_days = sorted(
-            [
+        board_heights = sorted(
+            {
                 self._to_int(row.get("today_continuous_days"))
                 for row in touched_rows
-                if self._to_int(row.get("today_continuous_days")) > 1
-            ],
+                if self._to_int(row.get("today_continuous_days")) > 0
+            },
             reverse=True,
         )
 
@@ -74,8 +74,8 @@ class MarketReviewMetricsService:
             "continuous_count": len(
                 [row for row in touched_rows if self._to_int(row.get("today_continuous_days")) >= 2]
             ),
-            "max_board_height": ladder_days[0] if ladder_days else 0,
-            "second_board_height": ladder_days[1] if len(ladder_days) > 1 else 0,
+            "max_board_height": board_heights[0] if board_heights else 0,
+            "second_board_height": board_heights[1] if len(board_heights) > 1 else 0,
             "gem_board_height": max(gem_days) if gem_days else 0,
             "first_to_second_rate": round(len(promoted_first_board) * 100 / len(yesterday_first_board), 2)
             if yesterday_first_board

--- a/backend/app/services/market_review_metrics_service.py
+++ b/backend/app/services/market_review_metrics_service.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List
+
+
+class MarketReviewMetricsService:
+    """Pure aggregation service for end-of-day market review metrics."""
+
+    def aggregate_daily_metrics(
+        self,
+        trade_date: date,
+        stock_rows: List[Dict],
+        limit_down_count: int,
+        market_turnover: float,
+        up_count_ex_st: int,
+        down_count_ex_st: int,
+    ) -> Dict:
+        touched_rows = [row for row in stock_rows if row.get("today_touched_limit_up")]
+        sealed_rows = [row for row in touched_rows if row.get("today_sealed_close")]
+        opened_rows = [row for row in touched_rows if row.get("today_opened_close")]
+
+        ladder_days = sorted(
+            [
+                self._to_int(row.get("today_continuous_days"))
+                for row in touched_rows
+                if self._to_int(row.get("today_continuous_days")) > 1
+            ],
+            reverse=True,
+        )
+
+        yesterday_first_board = [
+            row
+            for row in stock_rows
+            if row.get("yesterday_limit_up") and self._to_int(row.get("yesterday_continuous_days")) == 1
+        ]
+        yesterday_continuous = [
+            row for row in stock_rows if self._to_int(row.get("yesterday_continuous_days")) >= 2
+        ]
+
+        promoted_first_board = [
+            row for row in yesterday_first_board if self._to_int(row.get("today_continuous_days")) >= 2
+        ]
+        promoted_continuous = [
+            row
+            for row in yesterday_continuous
+            if self._to_int(row.get("today_continuous_days")) > self._to_int(row.get("yesterday_continuous_days"))
+        ]
+
+        gem_days = [
+            self._to_int(row.get("today_continuous_days"))
+            for row in touched_rows
+            if row.get("board_type") in {"gem", "star"}
+        ]
+
+        def avg(values: List[float]) -> float:
+            return round(sum(values) / len(values), 2) if values else 0.0
+
+        yesterday_limit_up_changes = [
+            float(row.get("change_pct") or 0)
+            for row in stock_rows
+            if row.get("yesterday_limit_up")
+        ]
+        yesterday_continuous_changes = [
+            float(row.get("change_pct") or 0)
+            for row in stock_rows
+            if self._to_int(row.get("yesterday_continuous_days")) >= 2
+        ]
+
+        return {
+            "trade_date": trade_date,
+            "limit_up_count": len(touched_rows),
+            "limit_down_count": self._to_int(limit_down_count),
+            "continuous_count": len(
+                [row for row in touched_rows if self._to_int(row.get("today_continuous_days")) >= 2]
+            ),
+            "max_board_height": ladder_days[0] if ladder_days else 0,
+            "second_board_height": ladder_days[1] if len(ladder_days) > 1 else 0,
+            "gem_board_height": max(gem_days) if gem_days else 0,
+            "first_to_second_rate": round(len(promoted_first_board) * 100 / len(yesterday_first_board), 2)
+            if yesterday_first_board
+            else 0.0,
+            "continuous_promotion_rate": round(len(promoted_continuous) * 100 / len(yesterday_continuous), 2)
+            if yesterday_continuous
+            else 0.0,
+            "seal_rate": round(len(sealed_rows) * 100 / len(touched_rows), 2) if touched_rows else 0.0,
+            "yesterday_limit_up_avg_change": avg(yesterday_limit_up_changes),
+            "yesterday_continuous_avg_change": avg(yesterday_continuous_changes),
+            "market_turnover": float(market_turnover or 0),
+            "up_count_ex_st": self._to_int(up_count_ex_st),
+            "down_count_ex_st": self._to_int(down_count_ex_st),
+            "limit_up_amount": round(sum(float(row.get("amount") or 0) for row in touched_rows), 2),
+            "broken_amount": round(sum(float(row.get("amount") or 0) for row in opened_rows), 2),
+        }
+
+    def _to_int(self, value: object) -> int:
+        if value in (None, ""):
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+
+market_review_metrics_service = MarketReviewMetricsService()

--- a/backend/app/services/market_review_metrics_service.py
+++ b/backend/app/services/market_review_metrics_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import date
 from typing import Dict, List
 
+from app.utils.market_data_sanitizer import normalize_change_pct
+
 
 class MarketReviewMetricsService:
     """Pure aggregation service for end-of-day market review metrics."""
@@ -57,14 +59,18 @@ class MarketReviewMetricsService:
             return round(sum(values) / len(values), 2) if values else 0.0
 
         yesterday_limit_up_changes = [
-            float(row.get("change_pct") or 0)
+            change_pct
             for row in stock_rows
             if row.get("yesterday_limit_up")
+            for change_pct in [self._normalized_change_pct(row)]
+            if change_pct is not None
         ]
         yesterday_continuous_changes = [
-            float(row.get("change_pct") or 0)
+            change_pct
             for row in stock_rows
             if self._to_int(row.get("yesterday_continuous_days")) >= 2
+            for change_pct in [self._normalized_change_pct(row)]
+            if change_pct is not None
         ]
 
         return {
@@ -100,6 +106,13 @@ class MarketReviewMetricsService:
             return int(value)
         except (TypeError, ValueError):
             return 0
+
+    def _normalized_change_pct(self, row: Dict) -> float | None:
+        return normalize_change_pct(
+            row.get("change_pct"),
+            price=row.get("close_price") or row.get("current_price"),
+            amount=row.get("amount"),
+        )
 
 
 market_review_metrics_service = MarketReviewMetricsService()

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -186,7 +186,7 @@ class MarketReviewPipelineService:
         return False
 
     def _ensure_authoritative_payload(self, payload: Dict[str, Any]) -> None:
-        if payload.get("is_authoritative"):
+        if payload.get("is_authoritative") is True:
             return
         trade_date = payload.get("trade_date")
         source_status = payload.get("source_status") or (payload.get("metric_row") or {}).get("source_status")

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -42,6 +42,10 @@ class MarketReviewPipelineService:
         normalized: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         normalized_data = normalized or await self.source_service.collect_for_date(trade_date)
+        is_authoritative = self._resolve_authoritative_flag(
+            normalized_data,
+            default_when_unspecified=normalized is not None,
+        )
         stock_rows = [
             {**row, "trade_date": trade_date}
             for row in (normalized_data.get("stock_rows") or [])
@@ -59,10 +63,12 @@ class MarketReviewPipelineService:
             up_count_ex_st=normalized_data.get("up_count_ex_st", 0),
             down_count_ex_st=normalized_data.get("down_count_ex_st", 0),
         )
+        metric_row["trade_date"] = trade_date
         metric_row["source_status"] = normalized_data.get("source_status", "unknown")
 
         return {
             "trade_date": trade_date,
+            "is_authoritative": is_authoritative,
             "metric_row": metric_row,
             "stock_rows": stock_rows,
             "event_rows": event_rows,
@@ -70,15 +76,22 @@ class MarketReviewPipelineService:
         }
 
     async def persist_payload(self, db: AsyncSession, payload: Dict[str, Any]) -> Dict[str, int]:
+        self._ensure_authoritative_payload(payload)
         metric_row = dict(payload.get("metric_row") or {})
-        stock_rows = [dict(row) for row in payload.get("stock_rows") or []]
-        event_rows = [dict(row) for row in payload.get("event_rows") or []]
-        trade_date = self._resolve_trade_date(payload, metric_row, stock_rows, event_rows)
+        trade_date = self._resolve_trade_date(payload, metric_row)
+        metric_row["trade_date"] = trade_date
+        stock_rows = self._canonicalize_trade_date(
+            payload.get("stock_rows") or [],
+            trade_date=trade_date,
+        )
+        event_rows = self._canonicalize_trade_date(
+            payload.get("event_rows") or [],
+            trade_date=trade_date,
+        )
 
         if metric_row:
             await self._upsert_metric_row(db, metric_row)
-        if trade_date is not None:
-            await self._replace_trade_date_rows(db, trade_date, stock_rows, event_rows)
+        await self._replace_trade_date_rows(db, trade_date, stock_rows, event_rows)
 
         return {
             "metric_rows": 1 if metric_row else 0,
@@ -93,6 +106,7 @@ class MarketReviewPipelineService:
         normalized: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         payload = await self.build_payload_for_date(trade_date, normalized=normalized)
+        self._ensure_authoritative_payload(payload)
         payload["metric_row"]["calc_version"] = calc_version
 
         async with self.session_factory() as session:
@@ -166,28 +180,47 @@ class MarketReviewPipelineService:
         if event_rows:
             await self._upsert_event_rows(db, event_rows)
 
+    def _resolve_authoritative_flag(
+        self,
+        normalized_data: Dict[str, Any],
+        default_when_unspecified: bool,
+    ) -> bool:
+        if "is_authoritative" in normalized_data:
+            return bool(normalized_data["is_authoritative"])
+        return default_when_unspecified
+
+    def _ensure_authoritative_payload(self, payload: Dict[str, Any]) -> None:
+        if payload.get("is_authoritative"):
+            return
+        trade_date = payload.get("trade_date")
+        source_status = payload.get("source_status") or (payload.get("metric_row") or {}).get("source_status")
+        raise RuntimeError(
+            f"Market review payload for {trade_date} is not authoritative; "
+            f"refusing to persist source_status={source_status!r}"
+        )
+
     def _resolve_trade_date(
         self,
         payload: Dict[str, Any],
         metric_row: Dict[str, Any],
-        stock_rows: Iterable[Dict[str, Any]],
-        event_rows: Iterable[Dict[str, Any]],
-    ) -> Optional[date]:
-        candidates = [
-            payload.get("trade_date"),
-            metric_row.get("trade_date"),
-        ]
-        first_stock_row = next(iter(stock_rows), None)
-        first_event_row = next(iter(event_rows), None)
-        if first_stock_row is not None:
-            candidates.append(first_stock_row.get("trade_date"))
-        if first_event_row is not None:
-            candidates.append(first_event_row.get("trade_date"))
-
-        for candidate in candidates:
+    ) -> date:
+        for candidate in (payload.get("trade_date"), metric_row.get("trade_date")):
             if isinstance(candidate, date):
                 return candidate
-        return None
+        raise RuntimeError("Authoritative market review payload is missing trade_date")
+
+    def _canonicalize_trade_date(
+        self,
+        rows: Iterable[Dict[str, Any]],
+        trade_date: date,
+    ) -> list[Dict[str, Any]]:
+        return [
+            {
+                **dict(row),
+                "trade_date": trade_date,
+            }
+            for row in rows
+        ]
 
     def _filter_model_columns(self, model, row: Dict[str, Any]) -> Dict[str, Any]:
         allowed_columns = set(model.__table__.columns.keys())

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, Dict, Iterable, Optional
 
+from sqlalchemy import delete
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -72,13 +73,12 @@ class MarketReviewPipelineService:
         metric_row = dict(payload.get("metric_row") or {})
         stock_rows = [dict(row) for row in payload.get("stock_rows") or []]
         event_rows = [dict(row) for row in payload.get("event_rows") or []]
+        trade_date = self._resolve_trade_date(payload, metric_row, stock_rows, event_rows)
 
         if metric_row:
             await self._upsert_metric_row(db, metric_row)
-        if stock_rows:
-            await self._upsert_stock_rows(db, stock_rows)
-        if event_rows:
-            await self._upsert_event_rows(db, event_rows)
+        if trade_date is not None:
+            await self._replace_trade_date_rows(db, trade_date, stock_rows, event_rows)
 
         return {
             "metric_rows": 1 if metric_row else 0,
@@ -147,6 +147,47 @@ class MarketReviewPipelineService:
                     set_=update_values,
                 )
             )
+
+    async def _replace_trade_date_rows(
+        self,
+        db: AsyncSession,
+        trade_date: date,
+        stock_rows: Iterable[Dict[str, Any]],
+        event_rows: Iterable[Dict[str, Any]],
+    ) -> None:
+        await db.execute(
+            delete(MarketReviewStockDaily).where(MarketReviewStockDaily.trade_date == trade_date)
+        )
+        await db.execute(
+            delete(MarketReviewLimitUpEvent).where(MarketReviewLimitUpEvent.trade_date == trade_date)
+        )
+        if stock_rows:
+            await self._upsert_stock_rows(db, stock_rows)
+        if event_rows:
+            await self._upsert_event_rows(db, event_rows)
+
+    def _resolve_trade_date(
+        self,
+        payload: Dict[str, Any],
+        metric_row: Dict[str, Any],
+        stock_rows: Iterable[Dict[str, Any]],
+        event_rows: Iterable[Dict[str, Any]],
+    ) -> Optional[date]:
+        candidates = [
+            payload.get("trade_date"),
+            metric_row.get("trade_date"),
+        ]
+        first_stock_row = next(iter(stock_rows), None)
+        first_event_row = next(iter(event_rows), None)
+        if first_stock_row is not None:
+            candidates.append(first_stock_row.get("trade_date"))
+        if first_event_row is not None:
+            candidates.append(first_event_row.get("trade_date"))
+
+        for candidate in candidates:
+            if isinstance(candidate, date):
+                return candidate
+        return None
 
     def _filter_model_columns(self, model, row: Dict[str, Any]) -> Dict[str, Any]:
         allowed_columns = set(model.__table__.columns.keys())

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -182,7 +182,7 @@ class MarketReviewPipelineService:
         normalized_data: Dict[str, Any],
     ) -> bool:
         if "is_authoritative" in normalized_data:
-            return bool(normalized_data["is_authoritative"])
+            return normalized_data["is_authoritative"] is True
         return False
 
     def _ensure_authoritative_payload(self, payload: Dict[str, Any]) -> None:

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Iterable, Optional
+
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import async_session_maker
+from app.models.market_review import (
+    MarketReviewDailyMetric,
+    MarketReviewLimitUpEvent,
+    MarketReviewStockDaily,
+)
+from app.services.market_review_metrics_service import (
+    MarketReviewMetricsService,
+    market_review_metrics_service,
+)
+from app.services.market_review_source_service import (
+    MarketReviewSourceService,
+    market_review_source_service,
+)
+
+
+class MarketReviewPipelineService:
+    """Builds and persists market review payloads from normalized source rows."""
+
+    def __init__(
+        self,
+        metrics_service: Optional[MarketReviewMetricsService] = None,
+        source_service: Optional[MarketReviewSourceService] = None,
+        session_factory=async_session_maker,
+    ) -> None:
+        self.metrics_service = metrics_service or market_review_metrics_service
+        self.source_service = source_service or market_review_source_service
+        self.session_factory = session_factory
+
+    async def build_payload_for_date(
+        self,
+        trade_date: date,
+        normalized: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        normalized_data = normalized or await self.source_service.collect_for_date(trade_date)
+        stock_rows = normalized_data.get("stock_rows") or []
+        event_rows = normalized_data.get("event_rows") or []
+
+        for row in stock_rows:
+            row.setdefault("trade_date", trade_date)
+        for row in event_rows:
+            row.setdefault("trade_date", trade_date)
+
+        metric_row = self.metrics_service.aggregate_daily_metrics(
+            trade_date=trade_date,
+            stock_rows=stock_rows,
+            limit_down_count=normalized_data.get("limit_down_count", 0),
+            market_turnover=normalized_data.get("market_turnover", 0.0),
+            up_count_ex_st=normalized_data.get("up_count_ex_st", 0),
+            down_count_ex_st=normalized_data.get("down_count_ex_st", 0),
+        )
+        metric_row["source_status"] = normalized_data.get("source_status", "unknown")
+
+        return {
+            "trade_date": trade_date,
+            "metric_row": metric_row,
+            "stock_rows": stock_rows,
+            "event_rows": event_rows,
+            "source_status": metric_row["source_status"],
+        }
+
+    async def persist_payload(self, db: AsyncSession, payload: Dict[str, Any]) -> Dict[str, int]:
+        metric_row = dict(payload.get("metric_row") or {})
+        stock_rows = [dict(row) for row in payload.get("stock_rows") or []]
+        event_rows = [dict(row) for row in payload.get("event_rows") or []]
+
+        if metric_row:
+            await self._upsert_metric_row(db, metric_row)
+        if stock_rows:
+            await self._upsert_stock_rows(db, stock_rows)
+        if event_rows:
+            await self._upsert_event_rows(db, event_rows)
+
+        await db.commit()
+        return {
+            "metric_rows": 1 if metric_row else 0,
+            "stock_rows": len(stock_rows),
+            "event_rows": len(event_rows),
+        }
+
+    async def run_for_date(
+        self,
+        trade_date: date,
+        calc_version: int = 1,
+        normalized: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        payload = await self.build_payload_for_date(trade_date, normalized=normalized)
+        payload["metric_row"]["calc_version"] = calc_version
+
+        async with self.session_factory() as session:
+            await self.persist_payload(session, payload)
+
+        return payload
+
+    async def _upsert_metric_row(self, db: AsyncSession, metric_row: Dict[str, Any]) -> None:
+        values = self._filter_model_columns(MarketReviewDailyMetric, metric_row)
+        stmt = sqlite_insert(MarketReviewDailyMetric).values(**values)
+        update_values = {
+            key: stmt.excluded[key]
+            for key in values
+            if key not in {"id", "created_at", "trade_date"}
+        }
+        await db.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["trade_date"],
+                set_=update_values,
+            )
+        )
+
+    async def _upsert_stock_rows(self, db: AsyncSession, stock_rows: Iterable[Dict[str, Any]]) -> None:
+        values = [
+            self._filter_model_columns(MarketReviewStockDaily, row)
+            for row in stock_rows
+        ]
+        stmt = sqlite_insert(MarketReviewStockDaily).values(values)
+        update_values = {
+            key: stmt.excluded[key]
+            for key in values[0]
+            if key not in {"id", "created_at", "trade_date", "stock_code"}
+        }
+        await db.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["trade_date", "stock_code"],
+                set_=update_values,
+            )
+        )
+
+    async def _upsert_event_rows(self, db: AsyncSession, event_rows: Iterable[Dict[str, Any]]) -> None:
+        values = [
+            self._filter_model_columns(MarketReviewLimitUpEvent, row)
+            for row in event_rows
+        ]
+        stmt = sqlite_insert(MarketReviewLimitUpEvent).values(values)
+        update_values = {
+            key: stmt.excluded[key]
+            for key in values[0]
+            if key not in {"id", "created_at", "trade_date", "stock_code", "event_type", "event_seq"}
+        }
+        await db.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["trade_date", "stock_code", "event_type", "event_seq"],
+                set_=update_values,
+            )
+        )
+
+    def _filter_model_columns(self, model, row: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_columns = set(model.__table__.columns.keys())
+        return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+market_review_pipeline_service = MarketReviewPipelineService()

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -42,10 +42,7 @@ class MarketReviewPipelineService:
         normalized: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         normalized_data = normalized or await self.source_service.collect_for_date(trade_date)
-        is_authoritative = self._resolve_authoritative_flag(
-            normalized_data,
-            default_when_unspecified=normalized is not None,
-        )
+        is_authoritative = self._resolve_authoritative_flag(normalized_data)
         stock_rows = [
             {**row, "trade_date": trade_date}
             for row in (normalized_data.get("stock_rows") or [])
@@ -183,11 +180,10 @@ class MarketReviewPipelineService:
     def _resolve_authoritative_flag(
         self,
         normalized_data: Dict[str, Any],
-        default_when_unspecified: bool,
     ) -> bool:
         if "is_authoritative" in normalized_data:
             return bool(normalized_data["is_authoritative"])
-        return default_when_unspecified
+        return False
 
     def _ensure_authoritative_payload(self, payload: Dict[str, Any]) -> None:
         if payload.get("is_authoritative"):

--- a/backend/app/services/market_review_pipeline_service.py
+++ b/backend/app/services/market_review_pipeline_service.py
@@ -41,13 +41,14 @@ class MarketReviewPipelineService:
         normalized: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         normalized_data = normalized or await self.source_service.collect_for_date(trade_date)
-        stock_rows = normalized_data.get("stock_rows") or []
-        event_rows = normalized_data.get("event_rows") or []
-
-        for row in stock_rows:
-            row.setdefault("trade_date", trade_date)
-        for row in event_rows:
-            row.setdefault("trade_date", trade_date)
+        stock_rows = [
+            {**row, "trade_date": trade_date}
+            for row in (normalized_data.get("stock_rows") or [])
+        ]
+        event_rows = [
+            {**row, "trade_date": trade_date}
+            for row in (normalized_data.get("event_rows") or [])
+        ]
 
         metric_row = self.metrics_service.aggregate_daily_metrics(
             trade_date=trade_date,
@@ -79,7 +80,6 @@ class MarketReviewPipelineService:
         if event_rows:
             await self._upsert_event_rows(db, event_rows)
 
-        await db.commit()
         return {
             "metric_rows": 1 if metric_row else 0,
             "stock_rows": len(stock_rows),
@@ -97,6 +97,7 @@ class MarketReviewPipelineService:
 
         async with self.session_factory() as session:
             await self.persist_payload(session, payload)
+            await session.commit()
 
         return payload
 
@@ -116,40 +117,36 @@ class MarketReviewPipelineService:
         )
 
     async def _upsert_stock_rows(self, db: AsyncSession, stock_rows: Iterable[Dict[str, Any]]) -> None:
-        values = [
-            self._filter_model_columns(MarketReviewStockDaily, row)
-            for row in stock_rows
-        ]
-        stmt = sqlite_insert(MarketReviewStockDaily).values(values)
-        update_values = {
-            key: stmt.excluded[key]
-            for key in values[0]
-            if key not in {"id", "created_at", "trade_date", "stock_code"}
-        }
-        await db.execute(
-            stmt.on_conflict_do_update(
-                index_elements=["trade_date", "stock_code"],
-                set_=update_values,
+        for row in stock_rows:
+            values = self._filter_model_columns(MarketReviewStockDaily, row)
+            stmt = sqlite_insert(MarketReviewStockDaily).values(**values)
+            update_values = {
+                key: stmt.excluded[key]
+                for key in values
+                if key not in {"id", "created_at", "trade_date", "stock_code"}
+            }
+            await db.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["trade_date", "stock_code"],
+                    set_=update_values,
+                )
             )
-        )
 
     async def _upsert_event_rows(self, db: AsyncSession, event_rows: Iterable[Dict[str, Any]]) -> None:
-        values = [
-            self._filter_model_columns(MarketReviewLimitUpEvent, row)
-            for row in event_rows
-        ]
-        stmt = sqlite_insert(MarketReviewLimitUpEvent).values(values)
-        update_values = {
-            key: stmt.excluded[key]
-            for key in values[0]
-            if key not in {"id", "created_at", "trade_date", "stock_code", "event_type", "event_seq"}
-        }
-        await db.execute(
-            stmt.on_conflict_do_update(
-                index_elements=["trade_date", "stock_code", "event_type", "event_seq"],
-                set_=update_values,
+        for row in event_rows:
+            values = self._filter_model_columns(MarketReviewLimitUpEvent, row)
+            stmt = sqlite_insert(MarketReviewLimitUpEvent).values(**values)
+            update_values = {
+                key: stmt.excluded[key]
+                for key in values
+                if key not in {"id", "created_at", "trade_date", "stock_code", "event_type", "event_seq"}
+            }
+            await db.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["trade_date", "stock_code", "event_type", "event_seq"],
+                    set_=update_values,
+                )
             )
-        )
 
     def _filter_model_columns(self, model, row: Dict[str, Any]) -> Dict[str, Any]:
         allowed_columns = set(model.__table__.columns.keys())

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -10,6 +10,7 @@ class MarketReviewSourceService:
     async def collect_for_date(self, trade_date: date) -> Dict[str, Any]:
         return {
             "trade_date": trade_date,
+            "is_authoritative": False,
             "stock_rows": [],
             "event_rows": [],
             "limit_down_count": 0,

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict
+
+
+class MarketReviewSourceService:
+    """Placeholder source adapter that returns a stable normalized shape."""
+
+    async def collect_for_date(self, trade_date: date) -> Dict[str, Any]:
+        return {
+            "trade_date": trade_date,
+            "stock_rows": [],
+            "event_rows": [],
+            "limit_down_count": 0,
+            "market_turnover": 0.0,
+            "up_count_ex_st": 0,
+            "down_count_ex_st": 0,
+            "source_status": "placeholder",
+        }
+
+
+market_review_source_service = MarketReviewSourceService()

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -1,13 +1,597 @@
 from __future__ import annotations
 
-from datetime import date
-from typing import Any, Dict
+import asyncio
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional
+
+import httpx
+from loguru import logger
+from sqlalchemy import select
+
+from app.config import settings
+from app.database import async_session_maker
+from app.data_collectors.tencent_api import tencent_api
+from app.models.market_data import DailyStatistics
+from app.models.stock import Stock
+from app.services.realtime_limit_up_service import realtime_limit_up_service
+from app.crawlers.eastmoney_crawler import em_crawler
+NormalizedFetcher = Callable[[date], Awaitable[Dict[str, Any]]]
+ListFetcher = Callable[[date], Awaitable[list[Dict[str, Any]]]]
+QuoteFetcher = Callable[[list[str]], Awaitable[Dict[str, Dict[str, Any]]]]
+
+
+def _today_shanghai() -> date:
+    return datetime.now(ZoneInfo("Asia/Shanghai")).date()
 
 
 class MarketReviewSourceService:
-    """Placeholder source adapter that returns a stable normalized shape."""
+    """Collects authoritative market-review inputs from existing market sources."""
+
+    YESTERDAY_POOL_API = "https://push2ex.eastmoney.com/getYesterdayZTPool"
+
+    def __init__(
+        self,
+        session_factory=async_session_maker,
+        today_limit_up_fetcher: Optional[ListFetcher] = None,
+        yesterday_pool_fetcher: Optional[ListFetcher] = None,
+        quote_fetcher: Optional[QuoteFetcher] = None,
+        market_stats_fetcher: Optional[NormalizedFetcher] = None,
+        current_date_provider: Callable[[], date] = _today_shanghai,
+    ) -> None:
+        self.session_factory = session_factory
+        self.today_limit_up_fetcher = today_limit_up_fetcher or self._fetch_today_limit_up_rows
+        self.yesterday_pool_fetcher = yesterday_pool_fetcher or self._fetch_yesterday_pool
+        self.quote_fetcher = quote_fetcher or tencent_api.get_quotes_batch
+        self.market_stats_fetcher = market_stats_fetcher or self._fetch_market_stats
+        self.current_date_provider = current_date_provider
 
     async def collect_for_date(self, trade_date: date) -> Dict[str, Any]:
+        today_result, yesterday_result, market_stats = await asyncio.gather(
+            self.today_limit_up_fetcher(trade_date),
+            self.yesterday_pool_fetcher(trade_date),
+            self.market_stats_fetcher(trade_date),
+        )
+        today_rows, today_succeeded = self._unwrap_list_fetch_result(today_result)
+        yesterday_pool, yesterday_succeeded = self._unwrap_list_fetch_result(yesterday_result)
+
+        if not today_succeeded or not yesterday_succeeded:
+            logger.warning(
+                "Market review source incomplete for {}: today_succeeded={}, yesterday_succeeded={}",
+                trade_date,
+                today_succeeded,
+                yesterday_succeeded,
+            )
+            return self._placeholder_payload(trade_date)
+
+        union_codes = {
+            item.get("stock_code", "")
+            for item in today_rows
+            if item.get("stock_code")
+        }
+        union_codes.update(
+            item.get("c", "")
+            for item in yesterday_pool
+            if item.get("c")
+        )
+        union_codes.discard("")
+
+        if not union_codes:
+            return self._placeholder_payload(trade_date)
+
+        quotes: Dict[str, Dict[str, Any]] = {}
+        if trade_date == self.current_date_provider():
+            try:
+                quotes = await self.quote_fetcher(sorted(union_codes))
+            except Exception as exc:
+                logger.warning(f"Market review quote fetch failed for {trade_date}: {exc}")
+
+        stock_meta = self._build_stock_meta(today_rows, yesterday_pool, quotes)
+        stock_ids = await self._ensure_stock_ids(stock_meta)
+        stock_rows = self._build_stock_rows(
+            trade_date=trade_date,
+            today_rows=today_rows,
+            yesterday_pool=yesterday_pool,
+            quotes=quotes,
+            stock_ids=stock_ids,
+        )
+        event_rows = self._build_event_rows(
+            trade_date=trade_date,
+            today_rows=today_rows,
+            stock_ids=stock_ids,
+        )
+
+        source_status = "primary" if self._market_stats_present(market_stats) else "partial"
+        return {
+            "trade_date": trade_date,
+            "is_authoritative": True,
+            "stock_rows": stock_rows,
+            "event_rows": event_rows,
+            "limit_down_count": int(market_stats.get("limit_down_count", 0) or 0),
+            "market_turnover": float(market_stats.get("market_turnover", 0.0) or 0.0),
+            "up_count_ex_st": int(market_stats.get("up_count_ex_st", 0) or 0),
+            "down_count_ex_st": int(market_stats.get("down_count_ex_st", 0) or 0),
+            "source_status": source_status,
+        }
+
+    async def _fetch_today_limit_up_rows(self, trade_date: date) -> list[Dict[str, Any]]:
+        if trade_date == self.current_date_provider():
+            try:
+                realtime_rows = await realtime_limit_up_service.get_realtime_limit_up_list(trade_date)
+                if realtime_rows:
+                    return {
+                        "items": realtime_rows,
+                        "succeeded": True,
+                    }
+            except Exception as exc:
+                logger.warning(f"Realtime limit-up source failed for {trade_date}: {exc}")
+
+        try:
+            history_rows = await em_crawler.crawl(trade_date)
+            return {
+                "items": history_rows or [],
+                "succeeded": True,
+            }
+        except Exception as exc:
+            logger.warning(f"EastMoney limit-up history source failed for {trade_date}: {exc}")
+            return {
+                "items": [],
+                "succeeded": False,
+            }
+
+    async def _fetch_yesterday_pool(self, trade_date: date) -> list[Dict[str, Any]]:
+        params = {
+            "ut": "7eea3edcaed734bea9cbfc24409ed989",
+            "dpt": "wz.ztzt",
+            "Pageindex": "0",
+            "pagesize": "5000",
+            "sort": "zs:desc",
+            "date": trade_date.strftime("%Y%m%d"),
+        }
+        headers = {
+            "User-Agent": settings.CRAWLER_USER_AGENT,
+            "Referer": "https://quote.eastmoney.com/",
+        }
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=settings.CRAWLER_REQUEST_TIMEOUT,
+                verify=False,
+                headers=headers,
+            ) as client:
+                response = await client.get(self.YESTERDAY_POOL_API, params=params)
+            response.raise_for_status()
+            body = response.json()
+            return {
+                "items": list((body.get("data") or {}).get("pool") or []),
+                "succeeded": True,
+            }
+        except Exception as exc:
+            logger.warning(f"Yesterday limit-up pool fetch failed for {trade_date}: {exc}")
+            return {
+                "items": [],
+                "succeeded": False,
+            }
+
+    async def _fetch_market_stats(self, trade_date: date) -> Dict[str, Any]:
+        stored_stats = await self._load_daily_statistics(trade_date)
+        if trade_date != self.current_date_provider():
+            return stored_stats
+
+        try:
+            live_stats = await asyncio.to_thread(self._fetch_live_market_stats_sync)
+        except Exception as exc:
+            logger.warning(f"Live market snapshot fetch failed for {trade_date}: {exc}")
+            live_stats = {}
+
+        if not live_stats:
+            return stored_stats
+
+        return {
+            "limit_down_count": int(
+                live_stats.get("limit_down_count")
+                or stored_stats.get("limit_down_count", 0)
+                or 0
+            ),
+            "market_turnover": float(
+                live_stats.get("market_turnover")
+                or stored_stats.get("market_turnover", 0.0)
+                or 0.0
+            ),
+            "up_count_ex_st": int(
+                live_stats.get("up_count_ex_st")
+                or stored_stats.get("up_count_ex_st", 0)
+                or 0
+            ),
+            "down_count_ex_st": int(
+                live_stats.get("down_count_ex_st")
+                or stored_stats.get("down_count_ex_st", 0)
+                or 0
+            ),
+        }
+
+    async def _load_daily_statistics(self, trade_date: date) -> Dict[str, Any]:
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(DailyStatistics).where(DailyStatistics.trade_date == trade_date)
+            )
+            stats = result.scalar_one_or_none()
+
+        if stats is None:
+            return {}
+
+        return {
+            "limit_down_count": int(stats.limit_down_count or 0),
+            "market_turnover": 0.0,
+            "up_count_ex_st": int(stats.up_count or 0),
+            "down_count_ex_st": int(stats.down_count or 0),
+        }
+
+    def _fetch_live_market_stats_sync(self) -> Dict[str, Any]:
+        import akshare as ak
+        import pandas as pd
+
+        snapshot = ak.stock_zh_a_spot()
+        if snapshot is None or snapshot.empty:
+            return {}
+
+        names = snapshot.get("名称")
+        changes = pd.to_numeric(snapshot.get("涨跌幅"), errors="coerce").fillna(0.0)
+        amounts = pd.to_numeric(snapshot.get("成交额"), errors="coerce").fillna(0.0)
+        codes = snapshot.get("代码")
+
+        if names is None or codes is None:
+            return {}
+
+        non_st_mask = ~names.astype(str).str.contains("ST", na=False)
+        limit_down_count = 0
+        for raw_code, raw_name, raw_change in zip(codes.tolist(), names.tolist(), changes.tolist()):
+            stock_code = self._normalize_code(raw_code)
+            if not stock_code:
+                continue
+            if self._is_limit_down(self._to_float(raw_change), stock_code, str(raw_name or "")):
+                limit_down_count += 1
+
+        return {
+            "limit_down_count": int(limit_down_count),
+            "market_turnover": round(float(amounts.sum()) / 100000000, 2),
+            "up_count_ex_st": int(((changes > 0) & non_st_mask).sum()),
+            "down_count_ex_st": int(((changes < 0) & non_st_mask).sum()),
+        }
+
+    def _build_stock_meta(
+        self,
+        today_rows: Iterable[Dict[str, Any]],
+        yesterday_pool: Iterable[Dict[str, Any]],
+        quotes: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, Dict[str, Any]]:
+        meta: Dict[str, Dict[str, Any]] = {}
+
+        for item in today_rows:
+            stock_code = item.get("stock_code", "")
+            if not stock_code:
+                continue
+            stock_name = item.get("stock_name", "") or quotes.get(stock_code, {}).get("name", "")
+            meta[stock_code] = {
+                "stock_code": stock_code,
+                "stock_name": stock_name or stock_code,
+                "market": self._detect_market(stock_code),
+                "is_st": self._is_st_name(stock_name),
+                "is_kc": int(stock_code.startswith("688")),
+                "is_cy": int(stock_code.startswith("300")),
+            }
+
+        for item in yesterday_pool:
+            stock_code = item.get("c", "")
+            if not stock_code:
+                continue
+            stock_name = item.get("n", "") or quotes.get(stock_code, {}).get("name", "")
+            meta.setdefault(
+                stock_code,
+                {
+                    "stock_code": stock_code,
+                    "stock_name": stock_name or stock_code,
+                    "market": self._detect_market(stock_code),
+                    "is_st": self._is_st_name(stock_name),
+                    "is_kc": int(stock_code.startswith("688")),
+                    "is_cy": int(stock_code.startswith("300")),
+                },
+            )
+
+        for stock_code, quote in quotes.items():
+            if not stock_code:
+                continue
+            meta.setdefault(
+                stock_code,
+                {
+                    "stock_code": stock_code,
+                    "stock_name": quote.get("name", "") or stock_code,
+                    "market": self._detect_market(stock_code),
+                    "is_st": self._is_st_name(quote.get("name", "")),
+                    "is_kc": int(stock_code.startswith("688")),
+                    "is_cy": int(stock_code.startswith("300")),
+                },
+            )
+
+        return meta
+
+    async def _ensure_stock_ids(self, stock_meta: Dict[str, Dict[str, Any]]) -> Dict[str, int]:
+        if not stock_meta:
+            return {}
+
+        codes = list(stock_meta.keys())
+        async with self.session_factory() as session:
+            existing_rows = (
+                await session.execute(
+                    select(Stock).where(Stock.stock_code.in_(codes))
+                )
+            ).scalars().all()
+            existing_map = {row.stock_code: row for row in existing_rows}
+
+            missing_codes = [code for code in codes if code not in existing_map]
+            if missing_codes:
+                for code in missing_codes:
+                    meta = stock_meta[code]
+                    session.add(
+                        Stock(
+                            stock_code=code,
+                            stock_name=meta["stock_name"],
+                            market=meta["market"],
+                            is_st=int(meta["is_st"]),
+                            is_kc=int(meta["is_kc"]),
+                            is_cy=int(meta["is_cy"]),
+                        )
+                    )
+                await session.commit()
+
+                existing_rows = (
+                    await session.execute(
+                        select(Stock).where(Stock.stock_code.in_(codes))
+                    )
+                ).scalars().all()
+                existing_map = {row.stock_code: row for row in existing_rows}
+
+        return {
+            code: row.id
+            for code, row in existing_map.items()
+        }
+
+    def _build_stock_rows(
+        self,
+        trade_date: date,
+        today_rows: list[Dict[str, Any]],
+        yesterday_pool: list[Dict[str, Any]],
+        quotes: Dict[str, Dict[str, Any]],
+        stock_ids: Dict[str, int],
+    ) -> list[Dict[str, Any]]:
+        today_map = {
+            item.get("stock_code", ""): item
+            for item in today_rows
+            if item.get("stock_code")
+        }
+        yesterday_map = {
+            item.get("c", ""): item
+            for item in yesterday_pool
+            if item.get("c")
+        }
+
+        stock_rows: list[Dict[str, Any]] = []
+        for stock_code in sorted(set(today_map) | set(yesterday_map)):
+            today_item = today_map.get(stock_code, {})
+            yesterday_item = yesterday_map.get(stock_code, {})
+            quote = quotes.get(stock_code, {})
+            stock_name = (
+                today_item.get("stock_name")
+                or yesterday_item.get("n")
+                or quote.get("name")
+                or stock_code
+            )
+            today_continuous_days = self._to_int(
+                today_item.get("continuous_limit_up_days")
+                or today_item.get("today_continuous_days")
+            )
+            yesterday_continuous_days = self._to_int(yesterday_item.get("ylbc"))
+            if yesterday_continuous_days == 0 and today_continuous_days > 1:
+                yesterday_continuous_days = today_continuous_days - 1
+
+            today_touched_limit_up = bool(today_item)
+            today_sealed_close = self._is_sealed(today_item) if today_touched_limit_up else False
+            close_price = self._resolve_close_price(today_item, quote, stock_code, stock_name)
+            pre_close = self._resolve_pre_close(today_item, quote, stock_code, stock_name)
+            change_pct = self._resolve_change_pct(today_item, yesterday_item, quote, close_price, pre_close)
+
+            stock_rows.append(
+                {
+                    "trade_date": trade_date,
+                    "stock_id": stock_ids.get(stock_code),
+                    "stock_code": stock_code,
+                    "stock_name": stock_name,
+                    "board_type": self._detect_board_type(stock_code),
+                    "is_st": self._is_st_name(stock_name),
+                    "yesterday_limit_up": bool(yesterday_item) or yesterday_continuous_days > 0,
+                    "yesterday_continuous_days": yesterday_continuous_days,
+                    "today_touched_limit_up": today_touched_limit_up,
+                    "today_sealed_close": today_sealed_close,
+                    "today_opened_close": today_touched_limit_up and not today_sealed_close,
+                    "today_broken": today_touched_limit_up and not today_sealed_close,
+                    "today_continuous_days": today_continuous_days,
+                    "first_limit_time": self._as_time(today_item.get("first_limit_up_time")),
+                    "final_seal_time": self._as_time(today_item.get("final_seal_time")),
+                    "open_count": self._to_int(today_item.get("open_count")),
+                    "close_price": close_price,
+                    "pre_close": pre_close,
+                    "change_pct": change_pct,
+                    "amount": self._resolve_amount(today_item, quote),
+                    "turnover_rate": self._resolve_turnover_rate(today_item, quote),
+                    "tradable_market_value": self._to_float(today_item.get("tradable_market_value")),
+                    "limit_up_reason": today_item.get("limit_up_reason", "") or None,
+                    "data_quality_flag": "ok",
+                }
+            )
+
+        return stock_rows
+
+    def _build_event_rows(
+        self,
+        trade_date: date,
+        today_rows: list[Dict[str, Any]],
+        stock_ids: Dict[str, int],
+    ) -> list[Dict[str, Any]]:
+        event_rows: list[Dict[str, Any]] = []
+        for item in today_rows:
+            stock_code = item.get("stock_code", "")
+            if not stock_code or stock_code not in stock_ids:
+                continue
+
+            source_name = str(item.get("data_source") or "review")[:20]
+            stock_name = item.get("stock_name", "") or stock_code
+            first_limit_time = self._as_time(item.get("first_limit_up_time"))
+            if first_limit_time is not None:
+                event_rows.append(
+                    {
+                        "trade_date": trade_date,
+                        "stock_id": stock_ids[stock_code],
+                        "stock_code": stock_code,
+                        "stock_name": stock_name,
+                        "event_type": "first_seal",
+                        "event_time": first_limit_time,
+                        "event_seq": 1,
+                        "source_name": source_name,
+                        "payload_json": {
+                            "continuous_limit_up_days": self._to_int(
+                                item.get("continuous_limit_up_days")
+                                or item.get("today_continuous_days")
+                            ),
+                            "open_count": self._to_int(item.get("open_count")),
+                        },
+                    }
+                )
+
+            event_rows.append(
+                {
+                    "trade_date": trade_date,
+                    "stock_id": stock_ids[stock_code],
+                    "stock_code": stock_code,
+                    "stock_name": stock_name,
+                    "event_type": "close_sealed" if self._is_sealed(item) else "close_opened",
+                    "event_time": self._as_time(
+                        item.get("final_seal_time")
+                        or item.get("first_limit_up_time")
+                    ),
+                    "event_seq": 2,
+                    "source_name": source_name,
+                    "payload_json": {
+                        "is_sealed": self._is_sealed(item),
+                        "open_count": self._to_int(item.get("open_count")),
+                    },
+                }
+            )
+
+        return event_rows
+
+    def _resolve_close_price(
+        self,
+        today_item: Dict[str, Any],
+        quote: Dict[str, Any],
+        stock_code: str,
+        stock_name: str,
+    ) -> Optional[float]:
+        for value in (
+            quote.get("price"),
+            today_item.get("current_price"),
+            today_item.get("close_price"),
+        ):
+            resolved = self._to_float(value)
+            if resolved is not None and resolved > 0:
+                return resolved
+
+        if self._is_sealed(today_item):
+            limit_up_price = self._to_float(today_item.get("limit_up_price"))
+            if limit_up_price is not None and limit_up_price > 0:
+                return limit_up_price
+
+        return None
+
+    def _resolve_pre_close(
+        self,
+        today_item: Dict[str, Any],
+        quote: Dict[str, Any],
+        stock_code: str,
+        stock_name: str,
+    ) -> Optional[float]:
+        for value in (
+            quote.get("pre_close"),
+            today_item.get("pre_close"),
+        ):
+            resolved = self._to_float(value)
+            if resolved is not None and resolved > 0:
+                return resolved
+
+        if not self._is_sealed(today_item):
+            return None
+
+        limit_up_price = self._to_float(today_item.get("limit_up_price"))
+        if limit_up_price is None or limit_up_price <= 0:
+            return None
+
+        ratio = self._limit_ratio(stock_code, stock_name)
+        return round(limit_up_price / (1 + ratio), 4)
+
+    def _resolve_change_pct(
+        self,
+        today_item: Dict[str, Any],
+        yesterday_item: Dict[str, Any],
+        quote: Dict[str, Any],
+        close_price: Optional[float],
+        pre_close: Optional[float],
+    ) -> Optional[float]:
+        for value in (
+            quote.get("change_pct"),
+            today_item.get("change_pct"),
+            yesterday_item.get("zdp"),
+        ):
+            resolved = self._to_float(value)
+            if resolved is not None:
+                return round(resolved, 2)
+
+        if close_price is not None and pre_close not in (None, 0):
+            return round((close_price - pre_close) / pre_close * 100, 2)
+        return None
+
+    def _resolve_amount(self, today_item: Dict[str, Any], quote: Dict[str, Any]) -> float:
+        for value in (
+            quote.get("amount"),
+            today_item.get("amount"),
+        ):
+            resolved = self._to_float(value)
+            if resolved is not None:
+                return resolved
+        return 0.0
+
+    def _resolve_turnover_rate(self, today_item: Dict[str, Any], quote: Dict[str, Any]) -> Optional[float]:
+        for value in (
+            quote.get("turnover_rate"),
+            today_item.get("turnover_rate"),
+        ):
+            resolved = self._to_float(value)
+            if resolved is not None:
+                return resolved
+        return None
+
+    def _market_stats_present(self, market_stats: Dict[str, Any]) -> bool:
+        return any(
+            market_stats.get(field) not in (None, 0, 0.0)
+            for field in ("limit_down_count", "market_turnover", "up_count_ex_st", "down_count_ex_st")
+        )
+
+    def _unwrap_list_fetch_result(self, result: Any) -> tuple[list[Dict[str, Any]], bool]:
+        if isinstance(result, dict) and "items" in result:
+            items = result.get("items") or []
+            succeeded = bool(result.get("succeeded", False))
+            return list(items), succeeded
+        return list(result or []), True
+
+    def _placeholder_payload(self, trade_date: date) -> Dict[str, Any]:
         return {
             "trade_date": trade_date,
             "is_authoritative": False,
@@ -19,6 +603,91 @@ class MarketReviewSourceService:
             "down_count_ex_st": 0,
             "source_status": "placeholder",
         }
+
+    def _detect_market(self, stock_code: str) -> str:
+        if stock_code.startswith(("5", "6", "9")):
+            return "SH"
+        if stock_code.startswith("8"):
+            return "BJ"
+        return "SZ"
+
+    def _detect_board_type(self, stock_code: str) -> str:
+        if stock_code.startswith("688"):
+            return "star"
+        if stock_code.startswith("300"):
+            return "gem"
+        if stock_code.startswith("8"):
+            return "bj"
+        return "main"
+
+    def _is_limit_down(self, change_pct: Optional[float], stock_code: str, stock_name: str) -> bool:
+        if change_pct is None:
+            return False
+        if self._is_st_name(stock_name):
+            return change_pct <= -4.8
+        if stock_code.startswith("8"):
+            return change_pct <= -29.5
+        if stock_code.startswith(("300", "688")):
+            return change_pct <= -19.5
+        return change_pct <= -9.5
+
+    def _limit_ratio(self, stock_code: str, stock_name: str) -> float:
+        if self._is_st_name(stock_name):
+            return 0.05
+        if stock_code.startswith("8"):
+            return 0.30
+        if stock_code.startswith(("300", "688")):
+            return 0.20
+        return 0.10
+
+    def _is_sealed(self, item: Dict[str, Any]) -> bool:
+        if not item:
+            return False
+        if "is_sealed" in item:
+            return bool(item.get("is_sealed"))
+        if "is_final_sealed" in item:
+            return bool(item.get("is_final_sealed"))
+        return item.get("current_status") == "sealed"
+
+    def _as_time(self, value: Any) -> Optional[time]:
+        if value is None:
+            return None
+        if isinstance(value, time):
+            return value
+        if isinstance(value, datetime):
+            return value.time()
+        if isinstance(value, str):
+            for fmt in ("%H:%M:%S", "%H%M%S", "%H:%M"):
+                try:
+                    parsed = datetime.strptime(value, fmt)
+                    return parsed.time()
+                except ValueError:
+                    continue
+        return None
+
+    def _normalize_code(self, value: Any) -> str:
+        code = str(value or "").strip().lower()
+        if code.startswith(("sh", "sz", "bj")):
+            code = code[2:]
+        return code.zfill(6) if code.isdigit() else ""
+
+    def _is_st_name(self, stock_name: Any) -> bool:
+        name = str(stock_name or "")
+        return "ST" in name.upper()
+
+    def _to_int(self, value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _to_float(self, value: Any) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
 
 market_review_source_service = MarketReviewSourceService()

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import date, datetime, time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 from typing import Any, Awaitable, Callable, Dict, Iterable, Optional
 
@@ -29,6 +30,9 @@ class MarketReviewSourceService:
     """Collects authoritative market-review inputs from existing market sources."""
 
     YESTERDAY_POOL_API = "https://push2ex.eastmoney.com/getYesterdayZTPool"
+    EASTMONEY_STOCK_KLINE_API = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
+    HISTORICAL_BREADTH_WINDOW_DAYS = 60
+    HISTORICAL_BREADTH_MAX_WORKERS = 16
 
     def __init__(
         self,
@@ -45,6 +49,7 @@ class MarketReviewSourceService:
         self.quote_fetcher = quote_fetcher or tencent_api.get_quotes_batch
         self.market_stats_fetcher = market_stats_fetcher or self._fetch_market_stats
         self.current_date_provider = current_date_provider
+        self._historical_market_stats_cache: Dict[date, Dict[str, Any]] = {}
 
     async def collect_for_date(self, trade_date: date) -> Dict[str, Any]:
         today_result, yesterday_result, market_stats = await asyncio.gather(
@@ -176,7 +181,15 @@ class MarketReviewSourceService:
     async def _fetch_market_stats(self, trade_date: date) -> Dict[str, Any]:
         stored_stats = await self._load_daily_statistics(trade_date)
         if trade_date != self.current_date_provider():
-            return stored_stats
+            try:
+                historical_stats = await asyncio.to_thread(
+                    self._fetch_historical_market_stats_sync,
+                    trade_date,
+                )
+            except Exception as exc:
+                logger.warning(f"Historical market stats fetch failed for {trade_date}: {exc}")
+                historical_stats = {}
+            return self._merge_market_stats(historical_stats, stored_stats)
 
         try:
             live_stats = await asyncio.to_thread(self._fetch_live_market_stats_sync)
@@ -187,28 +200,7 @@ class MarketReviewSourceService:
         if not live_stats:
             return stored_stats
 
-        return {
-            "limit_down_count": int(
-                live_stats.get("limit_down_count")
-                or stored_stats.get("limit_down_count", 0)
-                or 0
-            ),
-            "market_turnover": float(
-                live_stats.get("market_turnover")
-                or stored_stats.get("market_turnover", 0.0)
-                or 0.0
-            ),
-            "up_count_ex_st": int(
-                live_stats.get("up_count_ex_st")
-                or stored_stats.get("up_count_ex_st", 0)
-                or 0
-            ),
-            "down_count_ex_st": int(
-                live_stats.get("down_count_ex_st")
-                or stored_stats.get("down_count_ex_st", 0)
-                or 0
-            ),
-        }
+        return self._merge_market_stats(live_stats, stored_stats)
 
     async def _load_daily_statistics(self, trade_date: date) -> Dict[str, Any]:
         async with self.session_factory() as session:
@@ -226,6 +218,202 @@ class MarketReviewSourceService:
             "up_count_ex_st": int(stats.up_count or 0),
             "down_count_ex_st": int(stats.down_count or 0),
         }
+
+    def _fetch_historical_market_stats_sync(self, trade_date: date) -> Dict[str, Any]:
+        stats = dict(self._historical_market_stats_cache.get(trade_date) or {})
+
+        try:
+            exchange_turnover = self._fetch_exchange_market_turnover_sync(trade_date)
+            if exchange_turnover:
+                stats["market_turnover"] = exchange_turnover
+        except Exception as exc:
+            logger.warning(f"Exchange market turnover fetch failed for {trade_date}: {exc}")
+
+        if not self._historical_breadth_present(stats):
+            try:
+                stats.update(self._fetch_historical_market_breadth_sync(trade_date))
+            except Exception as exc:
+                logger.warning(f"Historical market breadth fetch failed for {trade_date}: {exc}")
+
+        if stats:
+            cached = dict(self._historical_market_stats_cache.get(trade_date) or {})
+            cached.update(stats)
+            self._historical_market_stats_cache[trade_date] = cached
+        return stats
+
+    def _fetch_exchange_market_turnover_sync(self, trade_date: date) -> float:
+        import akshare as ak
+
+        trade_date_str = trade_date.strftime("%Y%m%d")
+        sse_df = ak.stock_sse_deal_daily(date=trade_date_str)
+        szse_df = ak.stock_szse_summary(date=trade_date_str)
+        return self._extract_exchange_market_turnover(sse_df, szse_df)
+
+    def _extract_exchange_market_turnover(self, sse_df: Any, szse_df: Any) -> float:
+        sse_turnover = self._extract_numeric_from_frame(
+            sse_df,
+            row_column="单日情况",
+            row_value="成交金额",
+            value_column="股票",
+        )
+        szse_turnover_yuan = self._extract_numeric_from_frame(
+            szse_df,
+            row_column="证券类别",
+            row_value="股票",
+            value_column="成交金额",
+        )
+        szse_turnover = szse_turnover_yuan / 100000000 if szse_turnover_yuan else 0.0
+        return round(float(sse_turnover or 0.0) + float(szse_turnover or 0.0), 2)
+
+    def _extract_numeric_from_frame(
+        self,
+        frame: Any,
+        row_column: str,
+        row_value: str,
+        value_column: str,
+    ) -> float:
+        if frame is None or getattr(frame, "empty", True):
+            return 0.0
+        if row_column not in frame or value_column not in frame:
+            return 0.0
+
+        matches = frame[frame[row_column].astype(str) == row_value]
+        if matches.empty:
+            return 0.0
+        return self._to_float(matches.iloc[0][value_column]) or 0.0
+
+    def _fetch_historical_market_breadth_sync(self, trade_date: date) -> Dict[str, Any]:
+        if self._historical_breadth_present(self._historical_market_stats_cache.get(trade_date, {})):
+            return self._historical_market_stats_cache[trade_date]
+
+        import akshare as ak
+
+        stock_df = ak.stock_info_a_code_name()
+        if stock_df is None or stock_df.empty:
+            return {}
+
+        end_date = self._resolve_historical_breadth_end_date(trade_date)
+        start_date = trade_date
+        stock_rows = [
+            {
+                "code": self._normalize_code(row.get("code")),
+                "name": str(row.get("name") or ""),
+            }
+            for row in stock_df.to_dict("records")
+        ]
+        stock_rows = [
+            row
+            for row in stock_rows
+            if row["code"] and row["code"][0] in {"0", "3", "4", "6", "8", "9"}
+        ]
+
+        window_stats: Dict[date, Dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=self.HISTORICAL_BREADTH_MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(
+                    self._fetch_one_stock_history_stats,
+                    row["code"],
+                    row["name"],
+                    start_date,
+                    end_date,
+                )
+                for row in stock_rows
+            ]
+            for future in as_completed(futures):
+                for row_date, row_stats in future.result().items():
+                    target = window_stats.setdefault(
+                        row_date,
+                        {
+                            "limit_down_count": 0,
+                            "up_count_ex_st": 0,
+                            "down_count_ex_st": 0,
+                        },
+                    )
+                    target["limit_down_count"] += row_stats.get("limit_down_count", 0)
+                    target["up_count_ex_st"] += row_stats.get("up_count_ex_st", 0)
+                    target["down_count_ex_st"] += row_stats.get("down_count_ex_st", 0)
+
+        for row_date, row_stats in window_stats.items():
+            cached = dict(self._historical_market_stats_cache.get(row_date) or {})
+            cached.update(row_stats)
+            self._historical_market_stats_cache[row_date] = cached
+
+        return self._historical_market_stats_cache.get(trade_date, {})
+
+    def _fetch_one_stock_history_stats(
+        self,
+        stock_code: str,
+        stock_name: str,
+        start_date: date,
+        end_date: date,
+    ) -> Dict[date, Dict[str, int]]:
+        import requests
+
+        params = {
+            "fields1": "f1,f2,f3,f4,f5,f6",
+            "fields2": "f51,f52,f53,f54,f55,f56,f57,f58,f59,f60,f61",
+            "ut": "7eea3edcaed734bea9cbfc24409ed989",
+            "klt": "101",
+            "fqt": "0",
+            "secid": f"{self._eastmoney_market_code(stock_code)}.{stock_code}",
+            "beg": start_date.strftime("%Y%m%d"),
+            "end": end_date.strftime("%Y%m%d"),
+        }
+        try:
+            session = requests.Session()
+            session.trust_env = False
+            response = session.get(
+                self.EASTMONEY_STOCK_KLINE_API,
+                params=params,
+                headers={
+                    "User-Agent": settings.CRAWLER_USER_AGENT,
+                    "Referer": "https://quote.eastmoney.com/",
+                },
+                timeout=settings.CRAWLER_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            klines = ((response.json().get("data") or {}).get("klines") or [])
+        except Exception:
+            return {}
+
+        stats: Dict[date, Dict[str, int]] = {}
+        is_st = self._is_st_name(stock_name)
+        for raw_line in klines:
+            parts = str(raw_line).split(",")
+            if len(parts) < 9:
+                continue
+            try:
+                row_date = datetime.strptime(parts[0], "%Y-%m-%d").date()
+            except ValueError:
+                continue
+            change_pct = self._to_float(parts[8])
+            if change_pct is None:
+                continue
+            row_stats = stats.setdefault(
+                row_date,
+                {
+                    "limit_down_count": 0,
+                    "up_count_ex_st": 0,
+                    "down_count_ex_st": 0,
+                },
+            )
+            if self._is_limit_down(change_pct, stock_code, stock_name):
+                row_stats["limit_down_count"] += 1
+            if not is_st and change_pct > 0:
+                row_stats["up_count_ex_st"] += 1
+            if not is_st and change_pct < 0:
+                row_stats["down_count_ex_st"] += 1
+
+        return stats
+
+    def _resolve_historical_breadth_end_date(self, trade_date: date) -> date:
+        current_date = self.current_date_provider()
+        if current_date <= trade_date:
+            return trade_date
+        return min(
+            current_date,
+            trade_date + timedelta(days=self.HISTORICAL_BREADTH_WINDOW_DAYS),
+        )
 
     def _fetch_live_market_stats_sync(self) -> Dict[str, Any]:
         import akshare as ak
@@ -258,6 +446,36 @@ class MarketReviewSourceService:
             "up_count_ex_st": int(((changes > 0) & non_st_mask).sum()),
             "down_count_ex_st": int(((changes < 0) & non_st_mask).sum()),
         }
+
+    def _merge_market_stats(self, primary: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "limit_down_count": int(
+                primary.get("limit_down_count")
+                or fallback.get("limit_down_count", 0)
+                or 0
+            ),
+            "market_turnover": float(
+                primary.get("market_turnover")
+                or fallback.get("market_turnover", 0.0)
+                or 0.0
+            ),
+            "up_count_ex_st": int(
+                primary.get("up_count_ex_st")
+                or fallback.get("up_count_ex_st", 0)
+                or 0
+            ),
+            "down_count_ex_st": int(
+                primary.get("down_count_ex_st")
+                or fallback.get("down_count_ex_st", 0)
+                or 0
+            ),
+        }
+
+    def _historical_breadth_present(self, stats: Dict[str, Any]) -> bool:
+        return any(
+            stats.get(field) not in (None, 0, 0.0)
+            for field in ("limit_down_count", "up_count_ex_st", "down_count_ex_st")
+        )
 
     def _build_stock_meta(
         self,
@@ -670,6 +888,9 @@ class MarketReviewSourceService:
         if code.startswith(("sh", "sz", "bj")):
             code = code[2:]
         return code.zfill(6) if code.isdigit() else ""
+
+    def _eastmoney_market_code(self, stock_code: str) -> int:
+        return 1 if stock_code.startswith("6") else 0
 
     def _is_st_name(self, stock_name: Any) -> bool:
         name = str(stock_name or "")

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -30,7 +30,7 @@ class MarketReviewSourceService:
     """Collects authoritative market-review inputs from existing market sources."""
 
     YESTERDAY_POOL_API = "https://push2ex.eastmoney.com/getYesterdayZTPool"
-    EASTMONEY_STOCK_KLINE_API = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
+    TENCENT_STOCK_KLINE_API = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
     HISTORICAL_BREADTH_WINDOW_DAYS = 60
     HISTORICAL_BREADTH_MAX_WORKERS = 16
 
@@ -304,7 +304,7 @@ class MarketReviewSourceService:
         stock_rows = [
             row
             for row in stock_rows
-            if row["code"] and row["code"][0] in {"0", "3", "4", "6", "8", "9"}
+            if row["code"] and row["code"].startswith(("0", "3", "6"))
         ]
 
         window_stats: Dict[date, Dict[str, Any]] = {}
@@ -347,47 +347,66 @@ class MarketReviewSourceService:
         start_date: date,
         end_date: date,
     ) -> Dict[date, Dict[str, int]]:
-        import requests
-
         params = {
-            "fields1": "f1,f2,f3,f4,f5,f6",
-            "fields2": "f51,f52,f53,f54,f55,f56,f57,f58,f59,f60,f61",
-            "ut": "7eea3edcaed734bea9cbfc24409ed989",
-            "klt": "101",
-            "fqt": "0",
-            "secid": f"{self._eastmoney_market_code(stock_code)}.{stock_code}",
-            "beg": start_date.strftime("%Y%m%d"),
-            "end": end_date.strftime("%Y%m%d"),
+            "param": (
+                f"{self._tencent_symbol(stock_code)},day,"
+                f"{(start_date - timedelta(days=10)).strftime('%Y-%m-%d')},"
+                f"{end_date.strftime('%Y-%m-%d')},320,qfq"
+            )
         }
         try:
-            session = requests.Session()
-            session.trust_env = False
-            response = session.get(
-                self.EASTMONEY_STOCK_KLINE_API,
+            import requests
+
+            response = requests.get(
+                self.TENCENT_STOCK_KLINE_API,
                 params=params,
                 headers={
                     "User-Agent": settings.CRAWLER_USER_AGENT,
-                    "Referer": "https://quote.eastmoney.com/",
+                    "Referer": "https://gu.qq.com/",
                 },
                 timeout=settings.CRAWLER_REQUEST_TIMEOUT,
             )
             response.raise_for_status()
-            klines = ((response.json().get("data") or {}).get("klines") or [])
+            symbol = self._tencent_symbol(stock_code)
+            stock_data = (response.json().get("data") or {}).get(symbol) or {}
+            klines = stock_data.get("qfqday") or stock_data.get("day") or []
         except Exception:
             return {}
 
+        return self._parse_tencent_stock_history_stats(
+            stock_code=stock_code,
+            stock_name=stock_name,
+            rows=klines,
+            count_start_date=start_date,
+        )
+
+    def _parse_tencent_stock_history_stats(
+        self,
+        stock_code: str,
+        stock_name: str,
+        rows: Iterable[Any],
+        count_start_date: date,
+    ) -> Dict[date, Dict[str, int]]:
         stats: Dict[date, Dict[str, int]] = {}
         is_st = self._is_st_name(stock_name)
-        for raw_line in klines:
-            parts = str(raw_line).split(",")
-            if len(parts) < 9:
+        previous_close: Optional[float] = None
+        for raw_row in rows:
+            parts = list(raw_row) if isinstance(raw_row, (list, tuple)) else str(raw_row).split(",")
+            if len(parts) < 3:
                 continue
             try:
                 row_date = datetime.strptime(parts[0], "%Y-%m-%d").date()
             except ValueError:
                 continue
-            change_pct = self._to_float(parts[8])
-            if change_pct is None:
+            close_price = self._to_float(parts[2])
+            if close_price is None or close_price <= 0:
+                continue
+            if previous_close in (None, 0):
+                previous_close = close_price
+                continue
+            change_pct = (close_price - previous_close) / previous_close * 100
+            previous_close = close_price
+            if row_date < count_start_date:
                 continue
             row_stats = stats.setdefault(
                 row_date,
@@ -889,8 +908,9 @@ class MarketReviewSourceService:
             code = code[2:]
         return code.zfill(6) if code.isdigit() else ""
 
-    def _eastmoney_market_code(self, stock_code: str) -> int:
-        return 1 if stock_code.startswith("6") else 0
+    def _tencent_symbol(self, stock_code: str) -> str:
+        prefix = "sh" if stock_code.startswith("6") else "sz"
+        return f"{prefix}{stock_code}"
 
     def _is_st_name(self, stock_name: Any) -> bool:
         name = str(stock_name or "")

--- a/backend/app/services/market_review_source_service.py
+++ b/backend/app/services/market_review_source_service.py
@@ -17,6 +17,7 @@ from app.models.market_data import DailyStatistics
 from app.models.stock import Stock
 from app.services.realtime_limit_up_service import realtime_limit_up_service
 from app.crawlers.eastmoney_crawler import em_crawler
+from app.utils.market_data_sanitizer import normalize_change_pct
 NormalizedFetcher = Callable[[date], Awaitable[Dict[str, Any]]]
 ListFetcher = Callable[[date], Awaitable[list[Dict[str, Any]]]]
 QuoteFetcher = Callable[[list[str]], Awaitable[Dict[str, Dict[str, Any]]]]
@@ -782,17 +783,24 @@ class MarketReviewSourceService:
         close_price: Optional[float],
         pre_close: Optional[float],
     ) -> Optional[float]:
-        for value in (
-            quote.get("change_pct"),
-            today_item.get("change_pct"),
-            yesterday_item.get("zdp"),
+        for value, price, amount in (
+            (quote.get("change_pct"), quote.get("price"), quote.get("amount")),
+            (
+                today_item.get("change_pct"),
+                today_item.get("current_price") or today_item.get("limit_up_price"),
+                today_item.get("amount"),
+            ),
+            (yesterday_item.get("zdp"), yesterday_item.get("p"), yesterday_item.get("amount")),
         ):
-            resolved = self._to_float(value)
+            resolved = normalize_change_pct(value, price=price, amount=amount)
             if resolved is not None:
-                return round(resolved, 2)
+                return resolved
 
         if close_price is not None and pre_close not in (None, 0):
-            return round((close_price - pre_close) / pre_close * 100, 2)
+            return normalize_change_pct(
+                (close_price - pre_close) / pre_close * 100,
+                price=close_price,
+            )
         return None
 
     def _resolve_amount(self, today_item: Dict[str, Any], quote: Dict[str, Any]) -> float:

--- a/backend/app/services/realtime_limit_up_service.py
+++ b/backend/app/services/realtime_limit_up_service.py
@@ -25,6 +25,7 @@ from app.crawlers.eastmoney_crawler import em_crawler
 from app.crawlers.tonghuashun_crawler import ths_crawler
 from app.data_collectors.tencent_api import tencent_api
 from app.services.tradable_market_value_service import tradable_market_value_service
+from app.utils.market_data_sanitizer import normalize_change_pct
 
 
 class RealtimeLimitUpService:
@@ -277,16 +278,28 @@ class RealtimeLimitUpService:
         stock_code = merged.get("stock_code", "")
 
         if quote:
-            current_price = quote.get("price", 0) or merged.get("limit_up_price", 0)
+            try:
+                quote_price = float(quote.get("price") or 0)
+            except (TypeError, ValueError):
+                quote_price = 0.0
+            current_price = quote_price if quote_price > 0 else merged.get("limit_up_price", 0)
             amount = quote.get("amount", 0) or merged.get("amount", 0)
             turnover_rate = quote.get("turnover_rate", 0) or merged.get("turnover_rate", 0)
-            change_pct = quote.get("change_pct")
+            change_pct = normalize_change_pct(
+                quote.get("change_pct"),
+                price=quote_price,
+                amount=quote.get("amount"),
+            )
             bid1_volume = quote.get("bid1_volume", 0)
         else:
             current_price = merged.get("limit_up_price", 0)
             amount = merged.get("amount", 0)
             turnover_rate = merged.get("turnover_rate", 0)
-            change_pct = None
+            change_pct = normalize_change_pct(
+                merged.get("change_pct"),
+                price=merged.get("current_price") or merged.get("limit_up_price"),
+                amount=merged.get("amount"),
+            )
             bid1_volume = 0
 
         is_sealed = bool(merged.get("is_final_sealed", True))

--- a/backend/app/utils/market_data_sanitizer.py
+++ b/backend/app/utils/market_data_sanitizer.py
@@ -1,0 +1,43 @@
+"""
+Shared guards for external market data fields.
+
+Some upstream quote APIs emit placeholder rows with price and amount set to zero
+and change_pct set to -100. Treat those as missing data, not real market moves.
+"""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+
+def normalize_change_pct(
+    value: object,
+    *,
+    price: object = None,
+    amount: object = None,
+) -> Optional[float]:
+    """Return a rounded percentage change, or None for known invalid sentinels."""
+    change_pct = _to_float(value)
+    if change_pct is None or not math.isfinite(change_pct):
+        return None
+
+    price_value = _to_float(price)
+    amount_value = _to_float(amount)
+
+    if price_value is not None and price_value <= 0:
+        return None
+    if change_pct <= -99.9 and (price_value is None or price_value <= 0) and (amount_value in (None, 0.0)):
+        return None
+    if change_pct < -100.0:
+        return None
+
+    return round(change_pct, 2)
+
+
+def _to_float(value: object) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,7 @@ webdriver-manager==4.0.1
 
 # 通达信数据
 pytdx==1.72
+akshare==1.16.88
 
 # 任务调度
 apscheduler==3.10.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ pydantic-settings==2.1.0
 
 # 异步HTTP请求
 httpx==0.26.0
-aiohttp==3.9.1
+aiohttp>=3.11.13,<4
 
 # 爬虫相关
 beautifulsoup4==4.12.3

--- a/backend/scripts/backfill_market_review.py
+++ b/backend/scripts/backfill_market_review.py
@@ -1,0 +1,68 @@
+"""
+手动回补市场复盘数据
+"""
+import argparse
+import asyncio
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.services.market_review_pipeline_service import market_review_pipeline_service
+from app.utils.time_utils import get_trading_dates
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Backfill market review data for a date range.")
+    parser.add_argument("--start", required=True, help="Start date in YYYY-MM-DD format.")
+    parser.add_argument("--end", required=True, help="End date in YYYY-MM-DD format.")
+    parser.add_argument(
+        "--calc-version",
+        type=int,
+        default=1,
+        help="Calc version passed to market_review_pipeline_service.run_for_date().",
+    )
+    return parser.parse_args()
+
+
+def parse_date(value: str):
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+async def backfill_market_review(start_date, end_date, calc_version: int):
+    if end_date < start_date:
+        raise ValueError("end date must be greater than or equal to start date")
+
+    trading_dates = get_trading_dates(start_date, end_date)
+    if not trading_dates:
+        print("No trading dates found in the supplied range.")
+        return
+
+    print(
+        f"Backfilling market review data from {start_date} to {end_date} "
+        f"({len(trading_dates)} trading days), calc_version={calc_version}"
+    )
+
+    for trade_date in trading_dates:
+        print(f"Processing {trade_date} ...")
+        await market_review_pipeline_service.run_for_date(
+            trade_date,
+            calc_version=calc_version,
+        )
+
+    print("Backfill completed.")
+
+
+def main():
+    args = parse_args()
+    start_date = parse_date(args.start)
+    end_date = parse_date(args.end)
+    asyncio.run(backfill_market_review(start_date, end_date, args.calc_version))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_market_review.py
+++ b/backend/scripts/backfill_market_review.py
@@ -4,16 +4,16 @@
 import argparse
 import asyncio
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
+from loguru import logger
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 from app.services.market_review_pipeline_service import market_review_pipeline_service
-from app.utils.time_utils import get_trading_dates
 
 
 def parse_args():
@@ -33,11 +33,48 @@ def parse_date(value: str):
     return datetime.strptime(value, "%Y-%m-%d").date()
 
 
+def _normalize_trade_calendar_date(raw_value):
+    if isinstance(raw_value, date):
+        return raw_value
+    if hasattr(raw_value, "date"):
+        return raw_value.date()
+    if isinstance(raw_value, str):
+        return datetime.strptime(raw_value, "%Y-%m-%d").date()
+    return None
+
+
+def _get_cn_trading_dates(start_date: date, end_date: date):
+    if end_date < start_date:
+        return []
+
+    try:
+        import akshare as ak
+
+        calendar_df = ak.tool_trade_date_hist_sina()
+    except Exception as exc:
+        logger.warning(f"Unable to resolve China trading calendar for market review backfill: {exc}")
+        return []
+
+    if "trade_date" not in calendar_df:
+        logger.warning("China trading calendar missing trade_date column for market review backfill")
+        return []
+
+    trading_dates = []
+    for raw_value in calendar_df["trade_date"].tolist():
+        trade_date = _normalize_trade_calendar_date(raw_value)
+        if trade_date is None:
+            continue
+        if start_date <= trade_date <= end_date:
+            trading_dates.append(trade_date)
+
+    return trading_dates
+
+
 async def backfill_market_review(start_date, end_date, calc_version: int):
     if end_date < start_date:
         raise ValueError("end date must be greater than or equal to start date")
 
-    trading_dates = get_trading_dates(start_date, end_date)
+    trading_dates = _get_cn_trading_dates(start_date, end_date)
     if not trading_dates:
         print("No trading dates found in the supplied range.")
         return

--- a/backend/scripts/backfill_market_review.py
+++ b/backend/scripts/backfill_market_review.py
@@ -16,6 +16,10 @@ if str(BACKEND_DIR) not in sys.path:
 from app.services.market_review_pipeline_service import market_review_pipeline_service
 
 
+class TradingCalendarLookupError(RuntimeError):
+    """Raised when the China trading calendar cannot be loaded reliably."""
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Backfill market review data for a date range.")
     parser.add_argument("--start", required=True, help="Start date in YYYY-MM-DD format.")
@@ -52,12 +56,14 @@ def _get_cn_trading_dates(start_date: date, end_date: date):
 
         calendar_df = ak.tool_trade_date_hist_sina()
     except Exception as exc:
-        logger.warning(f"Unable to resolve China trading calendar for market review backfill: {exc}")
-        return []
+        raise TradingCalendarLookupError(
+            f"Unable to resolve China trading calendar for market review backfill: {exc}"
+        ) from exc
 
     if "trade_date" not in calendar_df:
-        logger.warning("China trading calendar missing trade_date column for market review backfill")
-        return []
+        raise TradingCalendarLookupError(
+            "China trading calendar missing trade_date column for market review backfill"
+        )
 
     trading_dates = []
     for raw_value in calendar_df["trade_date"].tolist():

--- a/backend/tests/test_continuous_ladder_service.py
+++ b/backend/tests/test_continuous_ladder_service.py
@@ -96,6 +96,28 @@ class ContinuousLadderServiceTests(unittest.TestCase):
             ["opened", "broken"],
         )
 
+    def test_build_yesterday_ladder_drops_sentinel_change_pct(self):
+        ladders = self.service.build_yesterday_ladder(
+            [
+                {
+                    "c": "603272",
+                    "n": "联翔股份",
+                    "ylbc": 2,
+                    "zdp": -100.0,
+                    "p": 0,
+                    "amount": 0,
+                    "ltsz": 0.0,
+                }
+            ],
+            [],
+            min_days=2,
+        )
+
+        self.assertEqual(len(ladders), 1)
+        stock = ladders[0]["stocks"][0]
+        self.assertEqual(stock["stock_code"], "603272")
+        self.assertIsNone(stock["today_change_pct"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_daily_analysis_api.py
+++ b/backend/tests/test_daily_analysis_api.py
@@ -1,6 +1,7 @@
 import asyncio
 import unittest
 from datetime import date, datetime
+from unittest.mock import patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -10,8 +11,9 @@ from sqlalchemy.pool import StaticPool
 from app.api.v1.daily_analysis import router as daily_analysis_router
 from app.database import Base, get_db
 from app.models.limit_up import LimitUpRecord
-from app.models.market_review import MarketReviewStockDaily
+from app.models.market_review import DailyAnalysisRecord, MarketReviewStockDaily
 from app.models.stock import Stock
+from app.services.daily_analysis_service import daily_analysis_service
 
 
 class DailyAnalysisApiTests(unittest.TestCase):
@@ -129,6 +131,22 @@ class DailyAnalysisApiTests(unittest.TestCase):
                         turnover_rate=15,
                     ),
                     LimitUpRecord(
+                        stock_id=trend_20cm.id,
+                        trade_date=date(2026, 4, 25),
+                        first_limit_up_time=datetime(2026, 4, 25, 10, 5, 0),
+                        final_seal_time=datetime(2026, 4, 25, 10, 5, 0),
+                        reason_category="人工智能",
+                        limit_up_reason="机器人",
+                        continuous_limit_up_days=1,
+                        open_count=0,
+                        is_final_sealed=True,
+                        open_price=24,
+                        close_price=28.8,
+                        limit_up_price=28.8,
+                        amount=30000,
+                        turnover_rate=15,
+                    ),
+                    LimitUpRecord(
                         stock_id=popular_limit_down.id,
                         trade_date=date(2026, 4, 23),
                         first_limit_up_time=datetime(2026, 4, 23, 9, 40, 0),
@@ -161,6 +179,17 @@ class DailyAnalysisApiTests(unittest.TestCase):
                         turnover_rate=7,
                     ),
                 ]
+            )
+            session.add(
+                DailyAnalysisRecord(
+                    trade_date=date(2026, 4, 25),
+                    month="2026-04",
+                    auto_result={},
+                    manual_overrides={},
+                    calc_version=1,
+                    data_status="ready",
+                    generated_at=datetime(2026, 4, 25, 16, 0, 0),
+                )
             )
             session.add_all(
                 [
@@ -213,35 +242,38 @@ class DailyAnalysisApiTests(unittest.TestCase):
             await session.commit()
 
     def test_backfill_query_override_and_rebuild_preserves_manual_override(self):
-        backfill = self.client.post("/statistics/daily-analysis/backfill", json={"month": "2026-04"})
-        self.assertEqual(backfill.status_code, 200)
-        self.assertEqual(backfill.json()["built_count"], 2)
+        trading_dates = {date(2026, 4, 23), date(2026, 4, 24)}
+        with patch.object(daily_analysis_service, "_load_cn_trading_date_set", return_value=trading_dates):
+            backfill = self.client.post("/statistics/daily-analysis/backfill", json={"month": "2026-04"})
+            self.assertEqual(backfill.status_code, 200)
+            self.assertEqual(backfill.json()["built_count"], 2)
+            self.assertEqual(backfill.json()["removed_non_trading_count"], 1)
 
-        month = self.client.get("/statistics/daily-analysis", params={"month": "2026-04"})
-        self.assertEqual(month.status_code, 200)
-        rows = month.json()["data"]
-        self.assertEqual({row["trade_date"] for row in rows}, {"2026-04-23", "2026-04-24"})
-        latest = next(row for row in rows if row["trade_date"] == "2026-04-24")
-        self.assertEqual(latest["columns"]["连板唯一性"]["items"][0]["time"], "09:25:02")
-        negative_codes = {
-            item["stock_code"]
-            for item in latest["columns"]["负反馈"]["items"]
-        }
-        self.assertIn("002900", negative_codes)
-        self.assertNotIn("002901", negative_codes)
+            month = self.client.get("/statistics/daily-analysis", params={"month": "2026-04"})
+            self.assertEqual(month.status_code, 200)
+            rows = month.json()["data"]
+            self.assertEqual({row["trade_date"] for row in rows}, {"2026-04-23", "2026-04-24"})
+            latest = next(row for row in rows if row["trade_date"] == "2026-04-24")
+            self.assertEqual(latest["columns"]["连板唯一性"]["items"][0]["time"], "09:25:02")
+            negative_codes = {
+                item["stock_code"]
+                for item in latest["columns"]["负反馈"]["items"]
+            }
+            self.assertIn("002900", negative_codes)
+            self.assertNotIn("002901", negative_codes)
 
-        patched = self.client.patch(
-            "/statistics/daily-analysis/2026-04-24/overrides",
-            json={"overrides": {"辨识度": "人工确认：唯一高标"}},
-        )
-        self.assertEqual(patched.status_code, 200)
-        self.assertEqual(patched.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
-        self.assertTrue(patched.json()["columns"]["辨识度"]["is_manual"])
+            patched = self.client.patch(
+                "/statistics/daily-analysis/2026-04-24/overrides",
+                json={"overrides": {"辨识度": "人工确认：唯一高标"}},
+            )
+            self.assertEqual(patched.status_code, 200)
+            self.assertEqual(patched.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
+            self.assertTrue(patched.json()["columns"]["辨识度"]["is_manual"])
 
-        rebuilt = self.client.post("/statistics/daily-analysis/2026-04-24/rebuild")
-        self.assertEqual(rebuilt.status_code, 200)
-        self.assertEqual(rebuilt.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
-        self.assertTrue(rebuilt.json()["columns"]["辨识度"]["is_manual"])
+            rebuilt = self.client.post("/statistics/daily-analysis/2026-04-24/rebuild")
+            self.assertEqual(rebuilt.status_code, 200)
+            self.assertEqual(rebuilt.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
+            self.assertTrue(rebuilt.json()["columns"]["辨识度"]["is_manual"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_daily_analysis_api.py
+++ b/backend/tests/test_daily_analysis_api.py
@@ -1,0 +1,145 @@
+import asyncio
+import unittest
+from datetime import date, datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.api.v1.daily_analysis import router as daily_analysis_router
+from app.database import Base, get_db
+from app.models.limit_up import LimitUpRecord
+from app.models.stock import Stock
+
+
+class DailyAnalysisApiTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        self.Session = async_sessionmaker(self.engine, expire_on_commit=False)
+        asyncio.run(self._create_schema_and_seed())
+
+        app = FastAPI()
+        app.include_router(daily_analysis_router, prefix="/statistics/daily-analysis")
+
+        async def override_get_db():
+            async with self.Session() as session:
+                yield session
+
+        app.dependency_overrides[get_db] = override_get_db
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        asyncio.run(self.engine.dispose())
+
+    async def _create_schema_and_seed(self):
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with self.Session() as session:
+            leader = Stock(
+                stock_code="000001",
+                stock_name="唯一高标",
+                market="SZ",
+                industry="人工智能",
+                is_cy=0,
+                is_kc=0,
+            )
+            trend_20cm = Stock(
+                stock_code="300001",
+                stock_name="趋势二十",
+                market="SZ",
+                industry="人工智能",
+                is_cy=1,
+                is_kc=0,
+            )
+            session.add_all([leader, trend_20cm])
+            await session.flush()
+
+            session.add_all(
+                [
+                    LimitUpRecord(
+                        stock_id=leader.id,
+                        trade_date=date(2026, 4, 23),
+                        first_limit_up_time=datetime(2026, 4, 23, 9, 32, 0),
+                        final_seal_time=datetime(2026, 4, 23, 9, 32, 0),
+                        reason_category="人工智能",
+                        limit_up_reason="AI",
+                        continuous_limit_up_days=3,
+                        open_count=0,
+                        is_final_sealed=True,
+                        open_price=10,
+                        close_price=11,
+                        limit_up_price=11,
+                        amount=100000,
+                        turnover_rate=7,
+                    ),
+                    LimitUpRecord(
+                        stock_id=leader.id,
+                        trade_date=date(2026, 4, 24),
+                        first_limit_up_time=datetime(2026, 4, 25, 9, 25, 2),
+                        final_seal_time=datetime(2026, 4, 25, 9, 25, 2),
+                        reason_category="人工智能",
+                        limit_up_reason="AI",
+                        continuous_limit_up_days=4,
+                        open_count=0,
+                        is_final_sealed=True,
+                        open_price=12.1,
+                        close_price=12.1,
+                        limit_up_price=12.1,
+                        amount=120000,
+                        turnover_rate=8,
+                    ),
+                    LimitUpRecord(
+                        stock_id=trend_20cm.id,
+                        trade_date=date(2026, 4, 24),
+                        first_limit_up_time=datetime(2026, 4, 24, 10, 5, 0),
+                        final_seal_time=None,
+                        reason_category="人工智能",
+                        limit_up_reason="机器人",
+                        continuous_limit_up_days=1,
+                        open_count=2,
+                        is_final_sealed=False,
+                        open_price=20,
+                        close_price=22,
+                        limit_up_price=24,
+                        amplitude=24,
+                        amount=30000,
+                        turnover_rate=15,
+                    ),
+                ]
+            )
+            await session.commit()
+
+    def test_backfill_query_override_and_rebuild_preserves_manual_override(self):
+        backfill = self.client.post("/statistics/daily-analysis/backfill", json={"month": "2026-04"})
+        self.assertEqual(backfill.status_code, 200)
+        self.assertEqual(backfill.json()["built_count"], 2)
+
+        month = self.client.get("/statistics/daily-analysis", params={"month": "2026-04"})
+        self.assertEqual(month.status_code, 200)
+        rows = month.json()["data"]
+        self.assertEqual({row["trade_date"] for row in rows}, {"2026-04-23", "2026-04-24"})
+        latest = next(row for row in rows if row["trade_date"] == "2026-04-24")
+        self.assertEqual(latest["columns"]["连板唯一性"]["items"][0]["time"], "09:25:02")
+
+        patched = self.client.patch(
+            "/statistics/daily-analysis/2026-04-24/overrides",
+            json={"overrides": {"辨识度": "人工确认：唯一高标"}},
+        )
+        self.assertEqual(patched.status_code, 200)
+        self.assertEqual(patched.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
+        self.assertTrue(patched.json()["columns"]["辨识度"]["is_manual"])
+
+        rebuilt = self.client.post("/statistics/daily-analysis/2026-04-24/rebuild")
+        self.assertEqual(rebuilt.status_code, 200)
+        self.assertEqual(rebuilt.json()["columns"]["辨识度"]["content"], "人工确认：唯一高标")
+        self.assertTrue(rebuilt.json()["columns"]["辨识度"]["is_manual"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_daily_analysis_api.py
+++ b/backend/tests/test_daily_analysis_api.py
@@ -10,6 +10,7 @@ from sqlalchemy.pool import StaticPool
 from app.api.v1.daily_analysis import router as daily_analysis_router
 from app.database import Base, get_db
 from app.models.limit_up import LimitUpRecord
+from app.models.market_review import MarketReviewStockDaily
 from app.models.stock import Stock
 
 
@@ -57,7 +58,23 @@ class DailyAnalysisApiTests(unittest.TestCase):
                 is_cy=1,
                 is_kc=0,
             )
-            session.add_all([leader, trend_20cm])
+            popular_limit_down = Stock(
+                stock_code="002900",
+                stock_name="人气跌停",
+                market="SZ",
+                industry="人工智能",
+                is_cy=0,
+                is_kc=0,
+            )
+            popular_slump = Stock(
+                stock_code="002901",
+                stock_name="人气大跌",
+                market="SZ",
+                industry="人工智能",
+                is_cy=0,
+                is_kc=0,
+            )
+            session.add_all([leader, trend_20cm, popular_limit_down, popular_slump])
             await session.flush()
 
             session.add_all(
@@ -111,6 +128,86 @@ class DailyAnalysisApiTests(unittest.TestCase):
                         amount=30000,
                         turnover_rate=15,
                     ),
+                    LimitUpRecord(
+                        stock_id=popular_limit_down.id,
+                        trade_date=date(2026, 4, 23),
+                        first_limit_up_time=datetime(2026, 4, 23, 9, 40, 0),
+                        final_seal_time=datetime(2026, 4, 23, 9, 40, 0),
+                        reason_category="人工智能",
+                        limit_up_reason="人形机器人",
+                        continuous_limit_up_days=3,
+                        open_count=0,
+                        is_final_sealed=True,
+                        open_price=9.1,
+                        close_price=10,
+                        limit_up_price=10,
+                        amount=90000,
+                        turnover_rate=8,
+                    ),
+                    LimitUpRecord(
+                        stock_id=popular_slump.id,
+                        trade_date=date(2026, 4, 23),
+                        first_limit_up_time=datetime(2026, 4, 23, 9, 42, 0),
+                        final_seal_time=datetime(2026, 4, 23, 9, 42, 0),
+                        reason_category="人工智能",
+                        limit_up_reason="人形机器人",
+                        continuous_limit_up_days=3,
+                        open_count=0,
+                        is_final_sealed=True,
+                        open_price=9.1,
+                        close_price=10,
+                        limit_up_price=10,
+                        amount=85000,
+                        turnover_rate=7,
+                    ),
+                ]
+            )
+            session.add_all(
+                [
+                    MarketReviewStockDaily(
+                        stock_id=popular_limit_down.id,
+                        trade_date=date(2026, 4, 24),
+                        stock_code="002900",
+                        stock_name="人气跌停",
+                        board_type="main",
+                        is_st=False,
+                        yesterday_limit_up=True,
+                        yesterday_continuous_days=3,
+                        today_touched_limit_up=False,
+                        today_sealed_close=False,
+                        today_opened_close=False,
+                        today_broken=False,
+                        today_continuous_days=0,
+                        close_price=9.05,
+                        pre_close=10.0,
+                        change_pct=-9.5,
+                        amount=70000,
+                        turnover_rate=11,
+                        limit_up_reason=None,
+                        data_quality_flag="ok",
+                    ),
+                    MarketReviewStockDaily(
+                        stock_id=popular_slump.id,
+                        trade_date=date(2026, 4, 24),
+                        stock_code="002901",
+                        stock_name="人气大跌",
+                        board_type="main",
+                        is_st=False,
+                        yesterday_limit_up=True,
+                        yesterday_continuous_days=3,
+                        today_touched_limit_up=False,
+                        today_sealed_close=False,
+                        today_opened_close=False,
+                        today_broken=False,
+                        today_continuous_days=0,
+                        close_price=9.3,
+                        pre_close=10.0,
+                        change_pct=-7.0,
+                        amount=65000,
+                        turnover_rate=10,
+                        limit_up_reason=None,
+                        data_quality_flag="ok",
+                    ),
                 ]
             )
             await session.commit()
@@ -126,6 +223,12 @@ class DailyAnalysisApiTests(unittest.TestCase):
         self.assertEqual({row["trade_date"] for row in rows}, {"2026-04-23", "2026-04-24"})
         latest = next(row for row in rows if row["trade_date"] == "2026-04-24")
         self.assertEqual(latest["columns"]["连板唯一性"]["items"][0]["time"], "09:25:02")
+        negative_codes = {
+            item["stock_code"]
+            for item in latest["columns"]["负反馈"]["items"]
+        }
+        self.assertIn("002900", negative_codes)
+        self.assertNotIn("002901", negative_codes)
 
         patched = self.client.patch(
             "/statistics/daily-analysis/2026-04-24/overrides",

--- a/backend/tests/test_daily_analysis_scheduler.py
+++ b/backend/tests/test_daily_analysis_scheduler.py
@@ -1,0 +1,18 @@
+import unittest
+
+from app.data_collectors.scheduler import DataScheduler
+
+
+class DailyAnalysisSchedulerTests(unittest.TestCase):
+    def test_start_registers_daily_analysis_after_close_job(self):
+        scheduler = DataScheduler()
+        scheduler.scheduler.start = lambda: None
+
+        scheduler.start()
+
+        job_ids = {job.id for job in scheduler.scheduler.get_jobs()}
+        self.assertIn("daily_analysis", job_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_daily_analysis_scheduler.py
+++ b/backend/tests/test_daily_analysis_scheduler.py
@@ -1,6 +1,8 @@
+import asyncio
 import unittest
 import sys
 import types
+from unittest.mock import patch
 
 apscheduler_module = types.ModuleType("apscheduler")
 schedulers_module = types.ModuleType("apscheduler.schedulers")
@@ -72,6 +74,15 @@ class DailyAnalysisSchedulerTests(unittest.TestCase):
 
         job_ids = {job["id"] for job in scheduler.scheduler.jobs}
         self.assertIn("daily_analysis", job_ids)
+
+    def test_calculate_daily_analysis_skips_non_trading_day(self):
+        scheduler = DataScheduler()
+
+        with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            return_value=None,
+        ):
+            asyncio.run(scheduler._calculate_daily_analysis())
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -260,6 +260,7 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
             ],
             fact("300001", trade_day, stock_name="重复二板甲", continuous_days=2, is_20cm=True, close_price=14.4, high_price=14.4, pre_close=12.0),
             fact("300002", trade_day, stock_name="重复二板乙", continuous_days=2, is_20cm=True, close_price=15.6, high_price=15.6, pre_close=13.0),
+            fact("300003", trade_dates[-2], stock_name="唯一三板", is_20cm=True, close_price=15.0, high_price=15.0, pre_close=12.5),
             fact("300003", trade_day, stock_name="唯一三板", continuous_days=3, is_20cm=True, close_price=18.0, high_price=18.0, pre_close=15.0),
             fact("300004", trade_day, stock_name="今日长影", sealed=False, open_count=2, is_20cm=True, close_price=10.8, high_price=12.4, pre_close=10.0),
             fact("300005", trade_dates[-3], stock_name="五日涨停新高", is_20cm=True, close_price=12.0, high_price=12.0, pre_close=10.0),

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -1,0 +1,136 @@
+import unittest
+from datetime import date, datetime
+
+from app.services.daily_analysis_service import (
+    DAILY_ANALYSIS_COLUMNS,
+    DailyAnalysisRuleEngine,
+    DailyAnalysisStockFact,
+)
+
+
+def fact(
+    stock_code: str,
+    trade_date: date,
+    *,
+    stock_name: str | None = None,
+    reason_category: str = "人工智能",
+    continuous_days: int = 1,
+    open_count: int = 0,
+    sealed: bool = True,
+    is_20cm: bool = False,
+    first_time: str = "09:35:00",
+    final_time: str | None = "09:35:00",
+    open_price: float = 10.0,
+    close_price: float = 11.0,
+    high_price: float = 11.0,
+    low_price: float = 9.8,
+    pre_close: float = 10.0,
+    amount: float = 10000.0,
+    turnover_rate: float = 8.0,
+) -> DailyAnalysisStockFact:
+    hh, mm, ss = [int(part) for part in first_time.split(":")]
+    first_limit_time = datetime(trade_date.year, trade_date.month, trade_date.day, hh, mm, ss)
+    final_limit_time = None
+    if final_time:
+        fh, fm, fs = [int(part) for part in final_time.split(":")]
+        final_limit_time = datetime(trade_date.year, trade_date.month, trade_date.day, fh, fm, fs)
+
+    return DailyAnalysisStockFact(
+        trade_date=trade_date,
+        stock_code=stock_code,
+        stock_name=stock_name or f"股票{stock_code[-2:]}",
+        reason_category=reason_category,
+        limit_up_reason=reason_category,
+        continuous_days=continuous_days,
+        open_count=open_count,
+        is_final_sealed=sealed,
+        is_20cm=is_20cm,
+        first_limit_time=first_limit_time,
+        final_seal_time=final_limit_time,
+        open_price=open_price,
+        close_price=close_price,
+        high_price=high_price,
+        low_price=low_price,
+        pre_close=pre_close,
+        change_pct=round((close_price - pre_close) / pre_close * 100, 2),
+        amount=amount,
+        turnover_rate=turnover_rate,
+    )
+
+
+class DailyAnalysisRuleEngineTests(unittest.TestCase):
+    def test_build_daily_result_flags_all_required_signal_columns(self):
+        trade_day = date(2026, 4, 24)
+        facts = [
+            fact("000001", trade_day, stock_name="唯一高标", continuous_days=4, first_time="09:31:00", amount=90000),
+            fact("300101", date(2026, 4, 22), stock_name="反包二十", sealed=False, open_count=4, close_price=10.2, high_price=12.0, pre_close=11.0, is_20cm=True),
+            fact("300101", trade_day, stock_name="反包二十", close_price=13.0, high_price=14.0, pre_close=10.8, is_20cm=True),
+            fact("300202", date(2026, 4, 21), stock_name="趋势二十", close_price=10.0, high_price=10.4, pre_close=9.8, is_20cm=True),
+            fact("300202", date(2026, 4, 22), stock_name="趋势二十", close_price=10.8, high_price=11.0, pre_close=10.0, is_20cm=True),
+            fact("300202", date(2026, 4, 23), stock_name="趋势二十", close_price=11.7, high_price=11.9, pre_close=10.8, is_20cm=True),
+            fact("300202", trade_day, stock_name="趋势二十", close_price=12.9, high_price=13.6, pre_close=11.7, is_20cm=True),
+            fact("002303", date(2026, 4, 18), stock_name="弹琴票", sealed=True, close_price=8.8, high_price=8.8, pre_close=8.0),
+            fact("002303", date(2026, 4, 21), stock_name="弹琴票", sealed=False, open_count=3, close_price=8.3, high_price=8.9, pre_close=8.6),
+            fact("002303", trade_day, stock_name="弹琴票", sealed=True, close_price=9.4, high_price=9.4, pre_close=8.6),
+            fact("002404", date(2026, 4, 23), stock_name="炸板反包", sealed=False, open_count=5, close_price=6.5, high_price=7.3, pre_close=6.8),
+            fact("002404", trade_day, stock_name="炸板反包", sealed=True, close_price=7.5, high_price=7.5, pre_close=6.5),
+            fact("002505", date(2026, 4, 15), stock_name="二波票", continuous_days=2, close_price=5.5, high_price=5.5, pre_close=5.0),
+            fact("002505", date(2026, 4, 19), stock_name="二波票", sealed=False, open_count=1, close_price=5.0, high_price=5.4, pre_close=5.2),
+            fact("002505", trade_day, stock_name="二波票", sealed=True, close_price=6.0, high_price=6.0, pre_close=5.4),
+            fact("300606", trade_day, stock_name="二十长影", sealed=False, open_count=2, is_20cm=True, close_price=10.8, high_price=12.4, pre_close=10.0),
+            fact("002707", trade_day, stock_name="一字套利", open_price=11.0, close_price=11.0, high_price=11.0, low_price=11.0, pre_close=10.0, first_time="09:25:02", final_time="09:25:02"),
+            fact("002808", date(2026, 4, 23), stock_name="昨日核心", continuous_days=3, first_time="09:30:00", amount=120000),
+            fact("002808", trade_day, stock_name="昨日核心", sealed=False, open_count=6, close_price=8.9, high_price=10.0, pre_close=9.8),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+
+        self.assertEqual(list(result.keys()), DAILY_ANALYSIS_COLUMNS[1:])
+        self.assertEqual(result["连板唯一性"]["items"][0]["stock_code"], "000001")
+        self.assertIn("唯一", result["连板唯一性"]["items"][0]["tags"])
+
+        combined_items = result["反包+趋势+弹钢琴"]["items"]
+        self.assertTrue(any(item["stock_code"] == "300101" and "反包" in item["tags"] for item in combined_items))
+        self.assertTrue(any(item["stock_code"] == "300202" and "趋势" in item["tags"] for item in combined_items))
+        self.assertTrue(any(item["stock_code"] == "002303" and "弹钢琴" in item["tags"] for item in combined_items))
+
+        self.assertTrue(any(item["stock_code"] == "002404" for item in result["炸板反包"]["items"]))
+        self.assertTrue(any(item["stock_code"] == "000001" for item in result["辨识度"]["items"]))
+        self.assertTrue(any(item["stock_code"] == "002505" for item in result["二波"]["items"]))
+        self.assertTrue(any(item["stock_code"] == "300606" and "长上影" in item["tags"] for item in result["20cm"]["items"]))
+        self.assertTrue(any(item["stock_code"] == "002707" for item in result["一字套利"]["items"]))
+        self.assertTrue(any(item["label"] == "人工智能" for item in result["板块"]["items"]))
+        self.assertTrue(any(item["stock_code"] == "002808" for item in result["负反馈"]["items"]))
+
+    def test_formats_times_by_clock_time_even_when_source_date_is_wrong(self):
+        trade_day = date(2026, 4, 24)
+        wrong_source_time = datetime(2026, 4, 25, 9, 25, 2)
+        stock = DailyAnalysisStockFact(
+            trade_date=trade_day,
+            stock_code="603318",
+            stock_name="水发燃气",
+            reason_category="其他",
+            limit_up_reason="燃气轮机",
+            continuous_days=3,
+            open_count=0,
+            is_final_sealed=True,
+            is_20cm=False,
+            first_limit_time=wrong_source_time,
+            final_seal_time=wrong_source_time,
+            open_price=10.0,
+            close_price=11.0,
+            high_price=11.0,
+            low_price=10.0,
+            pre_close=10.0,
+            change_pct=10.0,
+            amount=18000.0,
+            turnover_rate=5.9,
+        )
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, [stock])
+
+        self.assertEqual(result["连板唯一性"]["items"][0]["time"], "09:25:02")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -235,6 +235,57 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("202224", second_wave_codes)
         self.assertNotIn("202225", second_wave_codes)
 
+    def test_ongoing_second_wave_includes_current_high_board_after_prior_wave(self):
+        trade_dates = [
+            date(2026, 4, 21),
+            date(2026, 4, 22),
+            date(2026, 4, 23),
+            date(2026, 4, 24),
+            date(2026, 4, 27),
+            date(2026, 4, 28),
+            date(2026, 4, 29),
+            date(2026, 4, 30),
+            date(2026, 5, 5),
+            date(2026, 5, 6),
+            date(2026, 5, 7),
+        ]
+        trade_day = trade_dates[-1]
+        facts = [
+            *[
+                fact(
+                    f"9100{index:02d}",
+                    trade_date,
+                    stock_name=f"日期占位{index}",
+                    close_price=10 + index,
+                    high_price=10 + index,
+                    pre_close=9 + index,
+                )
+                for index, trade_date in enumerate(trade_dates)
+            ],
+            fact("002081", trade_dates[0], stock_name="金螳螂", continuous_days=1, close_price=4.49, high_price=4.49, pre_close=4.08),
+            fact("002081", trade_dates[1], stock_name="金螳螂", continuous_days=2, close_price=4.94, high_price=4.94, pre_close=4.49),
+            fact("002081", trade_dates[2], stock_name="金螳螂", continuous_days=3, close_price=5.43, high_price=5.43, pre_close=4.94),
+            fact("002081", trade_dates[6], stock_name="金螳螂", continuous_days=2, close_price=5.36, high_price=5.36, pre_close=4.87),
+            fact("002081", trade_dates[7], stock_name="金螳螂", continuous_days=3, close_price=5.90, high_price=5.90, pre_close=5.36),
+            fact("002081", trade_dates[8], stock_name="金螳螂", continuous_days=3, close_price=5.90, high_price=5.90, pre_close=5.36),
+            fact("002081", trade_dates[9], stock_name="金螳螂", continuous_days=4, close_price=6.49, high_price=6.49, pre_close=5.90),
+            fact("002081", trade_day, stock_name="金螳螂", continuous_days=5, close_price=7.14, high_price=7.14, pre_close=6.49),
+            fact("333333", trade_dates[6], stock_name="单波五板", continuous_days=1, close_price=3.3, high_price=3.3, pre_close=3.0),
+            fact("333333", trade_dates[7], stock_name="单波五板", continuous_days=2, close_price=3.6, high_price=3.6, pre_close=3.3),
+            fact("333333", trade_dates[8], stock_name="单波五板", continuous_days=3, close_price=4.0, high_price=4.0, pre_close=3.6),
+            fact("333333", trade_dates[9], stock_name="单波五板", continuous_days=4, close_price=4.4, high_price=4.4, pre_close=4.0),
+            fact("333333", trade_day, stock_name="单波五板", continuous_days=5, close_price=4.8, high_price=4.8, pre_close=4.4),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        second_wave_codes = {
+            item["stock_code"]
+            for item in result["二波"]["items"]
+        }
+
+        self.assertIn("002081", second_wave_codes)
+        self.assertNotIn("333333", second_wave_codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -152,6 +152,9 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
             fact("004444", earlier, stock_name="老票炸板", close_price=5.5, high_price=5.5, pre_close=5.0),
             fact("004444", yesterday, stock_name="老票炸板", sealed=False, open_count=5, close_price=5.1, high_price=5.7, pre_close=5.4),
             fact("004444", trade_day, stock_name="老票炸板", close_price=5.8, high_price=5.8, pre_close=5.1),
+            fact("005555", earlier, stock_name="连板弹琴", close_price=11.0, high_price=11.0, pre_close=10.0),
+            fact("005555", yesterday, stock_name="连板弹琴", open_count=2, close_price=12.0, high_price=12.0, pre_close=11.0),
+            fact("005555", trade_day, stock_name="连板弹琴", continuous_days=2, close_price=13.2, high_price=13.2, pre_close=12.0),
         ]
 
         result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
@@ -170,6 +173,7 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("002223", broken_codes)
         self.assertNotIn("003333", broken_codes)
         self.assertNotIn("004444", broken_codes)
+        self.assertNotIn("005555", combined_by_code)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -63,8 +63,8 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         trade_day = date(2026, 4, 24)
         facts = [
             fact("000001", trade_day, stock_name="唯一高标", continuous_days=4, first_time="09:31:00", amount=90000),
-            fact("300101", date(2026, 4, 21), stock_name="反包二十", close_price=11.0, high_price=11.0, pre_close=10.0, is_20cm=True),
-            fact("300101", date(2026, 4, 22), stock_name="反包二十", sealed=False, open_count=4, close_price=10.2, high_price=12.0, pre_close=11.0, is_20cm=True),
+            fact("300101", date(2026, 4, 22), stock_name="反包二十", close_price=11.0, high_price=11.0, pre_close=10.0, is_20cm=True),
+            fact("300101", date(2026, 4, 23), stock_name="反包二十", sealed=False, open_count=4, close_price=10.2, high_price=12.0, pre_close=11.0, is_20cm=True),
             fact("300101", trade_day, stock_name="反包二十", close_price=13.0, high_price=14.0, pre_close=10.8, is_20cm=True),
             fact("300202", date(2026, 4, 21), stock_name="趋势二十", close_price=10.0, high_price=10.4, pre_close=9.8, is_20cm=True),
             fact("300202", date(2026, 4, 22), stock_name="趋势二十", close_price=10.8, high_price=11.0, pre_close=10.0, is_20cm=True),
@@ -76,7 +76,7 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
             fact("002303", trade_day, stock_name="弹琴票", sealed=True, close_price=9.4, high_price=9.4, pre_close=8.6),
             fact("002404", date(2026, 4, 23), stock_name="炸板反包", sealed=False, open_count=5, close_price=6.5, high_price=7.3, pre_close=6.8),
             fact("002404", trade_day, stock_name="炸板反包", sealed=True, close_price=7.5, high_price=7.5, pre_close=6.5),
-            fact("002505", date(2026, 4, 15), stock_name="二波票", continuous_days=2, close_price=5.5, high_price=5.5, pre_close=5.0),
+            fact("002505", date(2026, 4, 15), stock_name="二波票", continuous_days=4, close_price=5.5, high_price=5.5, pre_close=5.0),
             fact("002505", date(2026, 4, 19), stock_name="二波票", sealed=False, open_count=1, close_price=5.0, high_price=5.4, pre_close=5.2),
             fact("002505", trade_day, stock_name="二波票", sealed=True, close_price=6.0, high_price=6.0, pre_close=5.4),
             fact("300606", trade_day, stock_name="二十长影", sealed=False, open_count=2, is_20cm=True, close_price=10.8, high_price=12.4, pre_close=10.0),
@@ -174,6 +174,66 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("003333", broken_codes)
         self.assertNotIn("004444", broken_codes)
         self.assertNotIn("005555", combined_by_code)
+
+    def test_rebound_and_second_wave_use_distinct_break_windows(self):
+        trade_dates = [
+            date(2026, 4, 10),
+            date(2026, 4, 13),
+            date(2026, 4, 14),
+            date(2026, 4, 15),
+            date(2026, 4, 16),
+            date(2026, 4, 17),
+            date(2026, 4, 20),
+            date(2026, 4, 21),
+            date(2026, 4, 22),
+            date(2026, 4, 23),
+            date(2026, 4, 24),
+        ]
+        trade_day = trade_dates[-1]
+        facts = [
+            *[
+                fact(
+                    f"9000{index:02d}",
+                    trade_date,
+                    stock_name=f"日期占位{index}",
+                    continuous_days=1,
+                    close_price=10 + index,
+                    high_price=10 + index,
+                    pre_close=9 + index,
+                )
+                for index, trade_date in enumerate(trade_dates)
+            ],
+            fact("101111", trade_dates[-3], stock_name="一日反包", close_price=11.0, high_price=11.0, pre_close=10.0),
+            fact("101111", trade_day, stock_name="一日反包", close_price=11.2, high_price=11.2, pre_close=10.1),
+            fact("101112", trade_dates[-4], stock_name="两日不反包", close_price=9.9, high_price=10.0, pre_close=9.0),
+            fact("101112", trade_day, stock_name="两日不反包", close_price=10.2, high_price=10.2, pre_close=9.4),
+            fact("202222", trade_dates[4], stock_name="四板二波", continuous_days=4, close_price=20.0, high_price=20.0, pre_close=18.2),
+            fact("202222", trade_day, stock_name="四板二波", close_price=20.2, high_price=20.2, pre_close=18.4),
+            fact("202223", trade_dates[4], stock_name="三板不二波", continuous_days=3, close_price=15.0, high_price=15.0, pre_close=13.6),
+            fact("202223", trade_day, stock_name="三板不二波", close_price=15.2, high_price=15.2, pre_close=13.8),
+            fact("202224", trade_dates[-3], stock_name="一日不二波", continuous_days=4, close_price=12.0, high_price=12.0, pre_close=10.9),
+            fact("202224", trade_day, stock_name="一日不二波", close_price=12.2, high_price=12.2, pre_close=11.1),
+            fact("202225", trade_dates[0], stock_name="太久不二波", continuous_days=4, close_price=8.0, high_price=8.0, pre_close=7.3),
+            fact("202225", trade_day, stock_name="太久不二波", close_price=8.2, high_price=8.2, pre_close=7.5),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        combined_by_code = {
+            item["stock_code"]: item
+            for item in result["反包+趋势+弹钢琴"]["items"]
+        }
+        second_wave_codes = {
+            item["stock_code"]
+            for item in result["二波"]["items"]
+        }
+
+        self.assertIn("101111", combined_by_code)
+        self.assertEqual(combined_by_code["101111"]["tags"], ["反包"])
+        self.assertNotIn("101112", combined_by_code)
+        self.assertIn("202222", second_wave_codes)
+        self.assertNotIn("202223", second_wave_codes)
+        self.assertNotIn("202224", second_wave_codes)
+        self.assertNotIn("202225", second_wave_codes)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -235,6 +235,64 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("202224", second_wave_codes)
         self.assertNotIn("202225", second_wave_codes)
 
+    def test_trend_excludes_continuous_boards_and_second_wave(self):
+        trade_dates = [
+            date(2026, 4, 10),
+            date(2026, 4, 13),
+            date(2026, 4, 14),
+            date(2026, 4, 15),
+            date(2026, 4, 16),
+            date(2026, 4, 17),
+            date(2026, 4, 20),
+            date(2026, 4, 21),
+            date(2026, 4, 22),
+            date(2026, 4, 23),
+            date(2026, 4, 24),
+        ]
+        trade_day = trade_dates[-1]
+        facts = [
+            *[
+                fact(
+                    f"9400{index:02d}",
+                    trade_date,
+                    stock_name=f"趋势日期占位{index}",
+                    continuous_days=1,
+                    close_price=10 + index,
+                    high_price=10 + index,
+                    pre_close=9 + index,
+                )
+                for index, trade_date in enumerate(trade_dates)
+            ],
+            fact("301111", trade_dates[-4], stock_name="普通趋势", sealed=False, close_price=10.0, high_price=10.2, pre_close=9.8),
+            fact("301111", trade_dates[-3], stock_name="普通趋势", sealed=False, close_price=10.7, high_price=10.9, pre_close=10.0),
+            fact("301111", trade_dates[-2], stock_name="普通趋势", sealed=False, close_price=11.4, high_price=11.6, pre_close=10.7),
+            fact("301111", trade_day, stock_name="普通趋势", sealed=False, close_price=12.2, high_price=12.4, pre_close=11.4),
+            fact("302222", trade_dates[-4], stock_name="连板趋势", sealed=False, close_price=9.5, high_price=9.7, pre_close=9.2),
+            fact("302222", trade_dates[-3], stock_name="连板趋势", close_price=10.0, high_price=10.0, pre_close=9.1),
+            fact("302222", trade_dates[-2], stock_name="连板趋势", continuous_days=2, close_price=11.0, high_price=11.0, pre_close=10.0),
+            fact("302222", trade_day, stock_name="连板趋势", continuous_days=3, close_price=12.1, high_price=12.1, pre_close=11.0),
+            fact("303333", trade_dates[3], stock_name="二波趋势", continuous_days=4, close_price=15.0, high_price=15.0, pre_close=13.6),
+            fact("303333", trade_dates[-4], stock_name="二波趋势", sealed=False, close_price=13.8, high_price=14.2, pre_close=13.5),
+            fact("303333", trade_dates[-3], stock_name="二波趋势", sealed=False, close_price=14.2, high_price=14.6, pre_close=13.8),
+            fact("303333", trade_dates[-2], stock_name="二波趋势", sealed=False, close_price=14.8, high_price=15.0, pre_close=14.2),
+            fact("303333", trade_day, stock_name="二波趋势", close_price=15.1, high_price=15.1, pre_close=13.7),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        combined_by_code = {
+            item["stock_code"]: item
+            for item in result["反包+趋势+弹钢琴"]["items"]
+        }
+        second_wave_codes = {
+            item["stock_code"]
+            for item in result["二波"]["items"]
+        }
+
+        self.assertEqual(combined_by_code["301111"]["tags"], ["趋势"])
+        self.assertNotIn("302222", combined_by_code)
+        self.assertNotIn("303333", combined_by_code)
+        self.assertIn("303333", second_wave_codes)
+
     def test_20cm_column_uses_only_unique_height_long_shadow_or_recent_limit_new_high(self):
         trade_dates = [
             date(2026, 4, 14),

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -63,12 +63,14 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         trade_day = date(2026, 4, 24)
         facts = [
             fact("000001", trade_day, stock_name="唯一高标", continuous_days=4, first_time="09:31:00", amount=90000),
+            fact("300101", date(2026, 4, 21), stock_name="反包二十", close_price=11.0, high_price=11.0, pre_close=10.0, is_20cm=True),
             fact("300101", date(2026, 4, 22), stock_name="反包二十", sealed=False, open_count=4, close_price=10.2, high_price=12.0, pre_close=11.0, is_20cm=True),
             fact("300101", trade_day, stock_name="反包二十", close_price=13.0, high_price=14.0, pre_close=10.8, is_20cm=True),
             fact("300202", date(2026, 4, 21), stock_name="趋势二十", close_price=10.0, high_price=10.4, pre_close=9.8, is_20cm=True),
             fact("300202", date(2026, 4, 22), stock_name="趋势二十", close_price=10.8, high_price=11.0, pre_close=10.0, is_20cm=True),
             fact("300202", date(2026, 4, 23), stock_name="趋势二十", close_price=11.7, high_price=11.9, pre_close=10.8, is_20cm=True),
             fact("300202", trade_day, stock_name="趋势二十", close_price=12.9, high_price=13.6, pre_close=11.7, is_20cm=True),
+            fact("002303", date(2026, 4, 16), stock_name="弹琴票", sealed=True, close_price=8.2, high_price=8.2, pre_close=7.5),
             fact("002303", date(2026, 4, 18), stock_name="弹琴票", sealed=True, close_price=8.8, high_price=8.8, pre_close=8.0),
             fact("002303", date(2026, 4, 21), stock_name="弹琴票", sealed=False, open_count=3, close_price=8.3, high_price=8.9, pre_close=8.6),
             fact("002303", trade_day, stock_name="弹琴票", sealed=True, close_price=9.4, high_price=9.4, pre_close=8.6),
@@ -90,6 +92,7 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertIn("唯一", result["连板唯一性"]["items"][0]["tags"])
 
         combined_items = result["反包+趋势+弹钢琴"]["items"]
+        self.assertTrue(all(len(item["tags"]) == 1 for item in combined_items))
         self.assertTrue(any(item["stock_code"] == "300101" and "反包" in item["tags"] for item in combined_items))
         self.assertTrue(any(item["stock_code"] == "300202" and "趋势" in item["tags"] for item in combined_items))
         self.assertTrue(any(item["stock_code"] == "002303" and "弹钢琴" in item["tags"] for item in combined_items))
@@ -130,6 +133,43 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         result = DailyAnalysisRuleEngine().build_daily_result(trade_day, [stock])
 
         self.assertEqual(result["连板唯一性"]["items"][0]["time"], "09:25:02")
+
+    def test_rebound_requires_one_plus_one_and_broken_rebound_requires_first_yesterday_break(self):
+        trade_day = date(2026, 4, 24)
+        yesterday = date(2026, 4, 23)
+        earlier = date(2026, 4, 22)
+        facts = [
+            fact("000001", trade_day, stock_name="市场日期占位", continuous_days=3),
+            fact("001111", earlier, stock_name="普通反包", close_price=11.0, high_price=11.0, pre_close=10.0),
+            fact("001111", yesterday, stock_name="普通反包", sealed=False, open_count=3, close_price=10.4, high_price=11.2, pre_close=11.0),
+            fact("001111", trade_day, stock_name="普通反包", close_price=11.3, high_price=11.3, pre_close=10.4),
+            fact("002222", yesterday, stock_name="首次炸板", sealed=False, open_count=5, close_price=6.5, high_price=7.3, pre_close=6.8),
+            fact("002222", trade_day, stock_name="首次炸板", close_price=7.5, high_price=7.5, pre_close=6.5),
+            fact("002223", yesterday, stock_name="炸板连板", sealed=False, open_count=5, close_price=6.5, high_price=7.3, pre_close=6.8),
+            fact("002223", trade_day, stock_name="炸板连板", continuous_days=2, close_price=7.5, high_price=7.5, pre_close=6.5),
+            fact("003333", earlier, stock_name="前日炸板", sealed=False, open_count=5, close_price=8.5, high_price=9.3, pre_close=8.8),
+            fact("003333", trade_day, stock_name="前日炸板", close_price=9.4, high_price=9.4, pre_close=8.5),
+            fact("004444", earlier, stock_name="老票炸板", close_price=5.5, high_price=5.5, pre_close=5.0),
+            fact("004444", yesterday, stock_name="老票炸板", sealed=False, open_count=5, close_price=5.1, high_price=5.7, pre_close=5.4),
+            fact("004444", trade_day, stock_name="老票炸板", close_price=5.8, high_price=5.8, pre_close=5.1),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        combined_by_code = {
+            item["stock_code"]: item
+            for item in result["反包+趋势+弹钢琴"]["items"]
+        }
+        broken_codes = {
+            item["stock_code"]
+            for item in result["炸板反包"]["items"]
+        }
+
+        self.assertEqual(combined_by_code["001111"]["tags"], ["反包"])
+        self.assertNotIn("002222", combined_by_code)
+        self.assertIn("002222", broken_codes)
+        self.assertNotIn("002223", broken_codes)
+        self.assertNotIn("003333", broken_codes)
+        self.assertNotIn("004444", broken_codes)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -14,6 +14,7 @@ def fact(
     *,
     stock_name: str | None = None,
     reason_category: str = "人工智能",
+    limit_up_reason: str | None = None,
     continuous_days: int = 1,
     open_count: int = 0,
     sealed: bool = True,
@@ -40,7 +41,7 @@ def fact(
         stock_code=stock_code,
         stock_name=stock_name or f"股票{stock_code[-2:]}",
         reason_category=reason_category,
-        limit_up_reason=reason_category,
+        limit_up_reason=limit_up_reason if limit_up_reason is not None else reason_category,
         continuous_days=continuous_days,
         open_count=open_count,
         is_final_sealed=sealed,
@@ -292,6 +293,64 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("302222", combined_by_code)
         self.assertNotIn("303333", combined_by_code)
         self.assertIn("303333", second_wave_codes)
+
+    def test_sector_items_use_source_themes_before_broad_reason_category(self):
+        trade_day = date(2026, 4, 24)
+        facts = [
+            fact(
+                "301001",
+                trade_day,
+                stock_name="机器人甲",
+                reason_category="人工智能",
+                limit_up_reason="人形机器人+RV减速器+XT减速器",
+                continuous_days=2,
+            ),
+            fact(
+                "301002",
+                trade_day,
+                stock_name="机器人乙",
+                reason_category="人工智能",
+                limit_up_reason="人形机器人+丝杠+商业航天",
+            ),
+            fact(
+                "301003",
+                trade_day,
+                stock_name="算力甲",
+                reason_category="人工智能",
+                limit_up_reason="算力租赁+Token工厂+通信网络管维",
+            ),
+            fact(
+                "301004",
+                trade_day,
+                stock_name="算力乙",
+                reason_category="人工智能",
+                limit_up_reason="Token工厂+AI政务+华为合作",
+                is_20cm=True,
+            ),
+            fact(
+                "301005",
+                trade_day,
+                stock_name="兜底票",
+                reason_category="医药医疗",
+                limit_up_reason="",
+            ),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        sector_by_label = {
+            item["label"]: item
+            for item in result["板块"]["items"]
+        }
+
+        self.assertIn("人形机器人", sector_by_label)
+        self.assertIn("Token工厂", sector_by_label)
+        self.assertIn("算力租赁", sector_by_label)
+        self.assertIn("医药医疗", sector_by_label)
+        self.assertNotIn("人工智能", sector_by_label)
+        self.assertIn("2只", sector_by_label["人形机器人"]["tags"])
+        self.assertIn("2只", sector_by_label["Token工厂"]["tags"])
+        self.assertIn("机器人甲(301001)", sector_by_label["人形机器人"]["content"])
+        self.assertIn("算力乙(301004)", sector_by_label["Token工厂"]["content"])
 
     def test_20cm_column_uses_only_unique_height_long_shadow_or_recent_limit_new_high(self):
         trade_dates = [

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -235,6 +235,64 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertNotIn("202224", second_wave_codes)
         self.assertNotIn("202225", second_wave_codes)
 
+    def test_20cm_column_uses_only_unique_height_long_shadow_or_recent_limit_new_high(self):
+        trade_dates = [
+            date(2026, 4, 14),
+            date(2026, 4, 17),
+            date(2026, 4, 20),
+            date(2026, 4, 21),
+            date(2026, 4, 22),
+            date(2026, 4, 23),
+            date(2026, 4, 24),
+        ]
+        trade_day = trade_dates[-1]
+        facts = [
+            *[
+                fact(
+                    f"9300{index:02d}",
+                    trade_date,
+                    stock_name=f"20cm日期占位{index}",
+                    close_price=10 + index,
+                    high_price=10 + index,
+                    pre_close=9 + index,
+                )
+                for index, trade_date in enumerate(trade_dates)
+            ],
+            fact("300001", trade_day, stock_name="重复二板甲", continuous_days=2, is_20cm=True, close_price=14.4, high_price=14.4, pre_close=12.0),
+            fact("300002", trade_day, stock_name="重复二板乙", continuous_days=2, is_20cm=True, close_price=15.6, high_price=15.6, pre_close=13.0),
+            fact("300003", trade_day, stock_name="唯一三板", continuous_days=3, is_20cm=True, close_price=18.0, high_price=18.0, pre_close=15.0),
+            fact("300004", trade_day, stock_name="今日长影", sealed=False, open_count=2, is_20cm=True, close_price=10.8, high_price=12.4, pre_close=10.0),
+            fact("300005", trade_dates[-3], stock_name="五日涨停新高", is_20cm=True, close_price=12.0, high_price=12.0, pre_close=10.0),
+            fact("300005", trade_day, stock_name="五日涨停新高", is_20cm=True, close_price=13.0, high_price=13.0, pre_close=10.83),
+            fact("300006", trade_dates[0], stock_name="超窗老涨停", is_20cm=True, close_price=12.0, high_price=12.0, pre_close=10.0),
+            fact("300006", trade_day, stock_name="超窗老涨停", is_20cm=True, close_price=13.0, high_price=13.0, pre_close=10.83),
+            fact("300007", trade_dates[-4], stock_name="纯趋势二十", sealed=False, is_20cm=True, close_price=10.0, high_price=10.2, pre_close=9.8),
+            fact("300007", trade_dates[-3], stock_name="纯趋势二十", sealed=False, is_20cm=True, close_price=10.7, high_price=10.9, pre_close=10.0),
+            fact("300007", trade_dates[-2], stock_name="纯趋势二十", sealed=False, is_20cm=True, close_price=11.5, high_price=11.7, pre_close=10.7),
+            fact("300007", trade_day, stock_name="纯趋势二十", sealed=False, is_20cm=True, close_price=12.2, high_price=12.4, pre_close=11.5),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        items_by_code = {
+            item["stock_code"]: item
+            for item in result["20cm"]["items"]
+        }
+
+        self.assertEqual(items_by_code["300003"]["tags"], ["唯一高度", "3板"])
+        self.assertEqual(items_by_code["300004"]["tags"], ["长上影"])
+        self.assertEqual(items_by_code["300005"]["tags"], ["5日涨停新高"])
+        self.assertNotIn("300001", items_by_code)
+        self.assertNotIn("300002", items_by_code)
+        self.assertNotIn("300006", items_by_code)
+        self.assertNotIn("300007", items_by_code)
+        self.assertTrue(
+            all(
+                tag in {"唯一高度", "3板", "长上影", "5日涨停新高"}
+                for item in items_by_code.values()
+                for tag in item["tags"]
+            )
+        )
+
     def test_ongoing_second_wave_includes_current_high_board_after_prior_wave(self):
         trade_dates = [
             date(2026, 4, 21),

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -286,6 +286,49 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertIn("002081", second_wave_codes)
         self.assertNotIn("333333", second_wave_codes)
 
+    def test_ongoing_second_wave_uses_board_height_reset_when_candidate_dates_are_sparse(self):
+        trade_dates = [
+            date(2026, 4, 21),
+            date(2026, 4, 22),
+            date(2026, 4, 23),
+            date(2026, 4, 24),
+            date(2026, 4, 29),
+            date(2026, 4, 30),
+            date(2026, 5, 5),
+            date(2026, 5, 6),
+            date(2026, 5, 7),
+        ]
+        trade_day = trade_dates[-1]
+        facts = [
+            *[
+                fact(
+                    f"9200{index:02d}",
+                    trade_date,
+                    stock_name=f"稀疏日期占位{index}",
+                    close_price=10 + index,
+                    high_price=10 + index,
+                    pre_close=9 + index,
+                )
+                for index, trade_date in enumerate(trade_dates)
+            ],
+            fact("002081", trade_dates[0], stock_name="金螳螂", continuous_days=1, close_price=4.49, high_price=4.49, pre_close=4.08),
+            fact("002081", trade_dates[1], stock_name="金螳螂", continuous_days=2, close_price=4.94, high_price=4.94, pre_close=4.49),
+            fact("002081", trade_dates[2], stock_name="金螳螂", continuous_days=3, close_price=5.43, high_price=5.43, pre_close=4.94),
+            fact("002081", trade_dates[4], stock_name="金螳螂", continuous_days=2, close_price=5.36, high_price=5.36, pre_close=4.87),
+            fact("002081", trade_dates[5], stock_name="金螳螂", continuous_days=3, close_price=5.90, high_price=5.90, pre_close=5.36),
+            fact("002081", trade_dates[6], stock_name="金螳螂", continuous_days=3, close_price=5.90, high_price=5.90, pre_close=5.36),
+            fact("002081", trade_dates[7], stock_name="金螳螂", continuous_days=4, close_price=6.49, high_price=6.49, pre_close=5.90),
+            fact("002081", trade_day, stock_name="金螳螂", continuous_days=5, close_price=7.14, high_price=7.14, pre_close=6.49),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        second_wave_codes = {
+            item["stock_code"]
+            for item in result["二波"]["items"]
+        }
+
+        self.assertIn("002081", second_wave_codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_daily_analysis_service.py
+++ b/backend/tests/test_daily_analysis_service.py
@@ -83,7 +83,7 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
             fact("300606", trade_day, stock_name="二十长影", sealed=False, open_count=2, is_20cm=True, close_price=10.8, high_price=12.4, pre_close=10.0),
             fact("002707", trade_day, stock_name="一字套利", open_price=11.0, close_price=11.0, high_price=11.0, low_price=11.0, pre_close=10.0, first_time="09:25:02", final_time="09:25:02"),
             fact("002808", date(2026, 4, 23), stock_name="昨日核心", continuous_days=3, first_time="09:30:00", amount=120000),
-            fact("002808", trade_day, stock_name="昨日核心", sealed=False, open_count=6, close_price=8.9, high_price=10.0, pre_close=9.8),
+            fact("002808", trade_day, stock_name="昨日核心", sealed=False, open_count=0, close_price=8.85, high_price=9.1, pre_close=9.8),
         ]
 
         result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
@@ -351,6 +351,34 @@ class DailyAnalysisRuleEngineTests(unittest.TestCase):
         self.assertIn("2只", sector_by_label["Token工厂"]["tags"])
         self.assertIn("机器人甲(301001)", sector_by_label["人形机器人"]["content"])
         self.assertIn("算力乙(301004)", sector_by_label["Token工厂"]["content"])
+
+    def test_negative_feedback_requires_popular_stock_limit_down(self):
+        trade_day = date(2026, 4, 24)
+        yesterday = date(2026, 4, 23)
+        facts = [
+            fact("001001", yesterday, stock_name="人气跌停", continuous_days=3, close_price=10.0, high_price=10.0, pre_close=9.1),
+            fact("001001", trade_day, stock_name="人气跌停", sealed=False, open_count=0, close_price=9.05, high_price=9.2, pre_close=10.0),
+            fact("001002", yesterday, stock_name="人气大跌", continuous_days=3, close_price=10.0, high_price=10.0, pre_close=9.1),
+            fact("001002", trade_day, stock_name="人气大跌", sealed=False, open_count=0, close_price=9.3, high_price=9.7, pre_close=10.0),
+            fact("001003", yesterday, stock_name="人气炸板", continuous_days=3, close_price=10.0, high_price=10.0, pre_close=9.1),
+            fact("001003", trade_day, stock_name="人气炸板", sealed=False, open_count=5, close_price=10.2, high_price=11.0, pre_close=10.0),
+            fact("001004", yesterday, stock_name="普通跌停", sealed=False, first_time="14:50:00", final_time=None, open_count=3, close_price=10.0, high_price=10.0, pre_close=9.5, amount=100, turnover_rate=1),
+            fact("001004", trade_day, stock_name="普通跌停", sealed=False, open_count=0, close_price=9.05, high_price=9.2, pre_close=10.0),
+            fact("300888", yesterday, stock_name="二十人气", is_20cm=True, close_price=12.0, high_price=12.0, pre_close=10.0, amount=90000),
+            fact("300888", trade_day, stock_name="二十人气", is_20cm=True, sealed=False, open_count=0, close_price=9.65, high_price=10.5, pre_close=12.0),
+        ]
+
+        result = DailyAnalysisRuleEngine().build_daily_result(trade_day, facts)
+        negative_by_code = {
+            item["stock_code"]: item
+            for item in result["负反馈"]["items"]
+        }
+
+        self.assertEqual(negative_by_code["001001"]["tags"], ["跌停"])
+        self.assertEqual(negative_by_code["300888"]["tags"], ["跌停"])
+        self.assertNotIn("001002", negative_by_code)
+        self.assertNotIn("001003", negative_by_code)
+        self.assertNotIn("001004", negative_by_code)
 
     def test_20cm_column_uses_only_unique_height_long_shadow_or_recent_limit_new_high(self):
         trade_dates = [

--- a/backend/tests/test_main_lifespan.py
+++ b/backend/tests/test_main_lifespan.py
@@ -1,0 +1,101 @@
+import unittest
+import sys
+import types
+from datetime import timedelta, tzinfo
+from unittest.mock import AsyncMock, MagicMock, patch
+
+apscheduler_module = types.ModuleType("apscheduler")
+schedulers_module = types.ModuleType("apscheduler.schedulers")
+asyncio_module = types.ModuleType("apscheduler.schedulers.asyncio")
+triggers_module = types.ModuleType("apscheduler.triggers")
+cron_module = types.ModuleType("apscheduler.triggers.cron")
+interval_module = types.ModuleType("apscheduler.triggers.interval")
+
+
+class StubAsyncIOScheduler:
+    def add_job(self, *args, **kwargs):
+        return None
+
+    def start(self):
+        return None
+
+    def shutdown(self):
+        return None
+
+
+class StubCronTrigger:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class StubIntervalTrigger:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+asyncio_module.AsyncIOScheduler = StubAsyncIOScheduler
+cron_module.CronTrigger = StubCronTrigger
+interval_module.IntervalTrigger = StubIntervalTrigger
+
+sys.modules.setdefault("apscheduler", apscheduler_module)
+sys.modules.setdefault("apscheduler.schedulers", schedulers_module)
+sys.modules.setdefault("apscheduler.schedulers.asyncio", asyncio_module)
+sys.modules.setdefault("apscheduler.triggers", triggers_module)
+sys.modules.setdefault("apscheduler.triggers.cron", cron_module)
+sys.modules.setdefault("apscheduler.triggers.interval", interval_module)
+
+
+class StubShanghaiTimezone(tzinfo):
+    zone = "Asia/Shanghai"
+
+    def utcoffset(self, dt):
+        return timedelta(hours=8)
+
+    def dst(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return self.zone
+
+
+pytz_module = types.ModuleType("pytz")
+pytz_module.timezone = lambda _: StubShanghaiTimezone()
+sys.modules.setdefault("pytz", pytz_module)
+
+from app import main as app_main
+
+
+class MainLifespanTests(unittest.IsolatedAsyncioTestCase):
+    async def test_lifespan_starts_and_stops_data_scheduler(self):
+        scheduler = MagicMock()
+
+        async def noop_initialize():
+            return None
+
+        def consume_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch.object(app_main, "setup_logging"), patch.object(
+            app_main, "init_db", AsyncMock()
+        ), patch.object(app_main, "close_db", AsyncMock()), patch.object(
+            app_main.event_bus, "start", AsyncMock()
+        ), patch.object(
+            app_main.event_bus, "stop", AsyncMock()
+        ), patch.object(
+            app_main.data_init_service, "initialize", side_effect=noop_initialize
+        ), patch.object(
+            app_main.asyncio, "create_task", side_effect=consume_task
+        ), patch.object(
+            app_main, "data_scheduler", scheduler
+        ):
+            async with app_main.lifespan(app_main.app):
+                scheduler.start.assert_called_once_with()
+
+        scheduler.stop.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_data_sanitizer.py
+++ b/backend/tests/test_market_data_sanitizer.py
@@ -1,0 +1,28 @@
+import unittest
+
+from app.utils.market_data_sanitizer import normalize_change_pct
+
+
+class MarketDataSanitizerTests(unittest.TestCase):
+    def test_normalize_change_pct_rejects_no_price_sentinel(self):
+        self.assertIsNone(
+            normalize_change_pct(
+                -100.0,
+                price=0,
+                amount=0,
+            )
+        )
+
+    def test_normalize_change_pct_keeps_valid_limit_move(self):
+        self.assertEqual(
+            normalize_change_pct(
+                10.028050422668457,
+                price=11770,
+                amount=123456.0,
+            ),
+            10.03,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -1,6 +1,9 @@
 import asyncio
+import importlib.util
+import sys
 import unittest
 from datetime import date, time
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -8,13 +11,27 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
 import app.models  # noqa: F401
-from app.api.v1.review import router as review_router
 from app.database import Base, get_db
 from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockDaily
 from app.models.stock import Stock
 
 
+def _load_review_router():
+    review_module_path = Path(__file__).resolve().parents[1] / "app" / "api" / "v1" / "review.py"
+    spec = importlib.util.spec_from_file_location("isolated_market_review_router", review_module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.router
+
+
+review_router = _load_review_router()
+
+
 class MarketReviewApiTests(unittest.TestCase):
+    def test_review_router_import_does_not_execute_api_v1_package(self):
+        self.assertNotIn("app.api.v1", sys.modules)
+
     def setUp(self):
         self.engine = create_async_engine(
             "sqlite+aiosqlite://",

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -206,6 +206,10 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual([row["trade_date"] for row in rows], ["2026-04-27", "2026-04-28"])
         self.assertEqual(rows[0]["limit_up_count"], 5)
         self.assertEqual(rows[1]["max_board_height"], 4)
+        self.assertEqual(payload["start_date"], "2026-04-27")
+        self.assertEqual(payload["end_date"], "2026-04-28")
+        self.assertEqual(payload["latest_trade_date"], "2026-04-28")
+        self.assertFalse(payload["is_fallback"])
 
         for field in (
             "trade_date",
@@ -227,6 +231,38 @@ class MarketReviewApiTests(unittest.TestCase):
             "broken_amount",
         ):
             self.assertIn(field, rows[0])
+
+    def test_daily_endpoint_resolves_future_end_date_to_latest_available_metric(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/daily",
+            params={"start_date": "2026-04-27", "end_date": "2026-05-02"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["series"], ["2026-04-27", "2026-04-28"])
+        self.assertEqual(payload["start_date"], "2026-04-27")
+        self.assertEqual(payload["end_date"], "2026-04-28")
+        self.assertEqual(payload["requested_start_date"], "2026-04-27")
+        self.assertEqual(payload["requested_end_date"], "2026-05-02")
+        self.assertEqual(payload["latest_trade_date"], "2026-04-28")
+        self.assertTrue(payload["is_fallback"])
+
+    def test_daily_endpoint_falls_back_to_latest_single_row_when_range_is_after_latest_metric(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/daily",
+            params={"start_date": "2026-05-02", "end_date": "2026-05-02"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["series"], ["2026-04-28"])
+        self.assertEqual(payload["start_date"], "2026-04-28")
+        self.assertEqual(payload["end_date"], "2026-04-28")
+        self.assertEqual(payload["requested_start_date"], "2026-05-02")
+        self.assertEqual(payload["requested_end_date"], "2026-05-02")
+        self.assertEqual(payload["latest_trade_date"], "2026-04-28")
+        self.assertTrue(payload["is_fallback"])
 
     def test_detail_endpoint_sorts_by_continuous_days_then_amount_desc(self):
         response = self.client.get(

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -1,0 +1,248 @@
+import asyncio
+import unittest
+from datetime import date
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.api.v1 import api_router
+from app.database import Base, get_db
+from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockDaily
+from app.models.stock import Stock
+
+
+class MarketReviewApiTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            expire_on_commit=False,
+        )
+        asyncio.run(self._create_schema())
+        asyncio.run(self._seed_data())
+
+        self.app = FastAPI()
+        self.app.include_router(api_router, prefix="/api/v1")
+
+        async def override_get_db():
+            async with self.session_factory() as session:
+                yield session
+
+        self.app.dependency_overrides[get_db] = override_get_db
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        self.client.close()
+        self.app.dependency_overrides.clear()
+        asyncio.run(self.engine.dispose())
+
+    async def _create_schema(self):
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    async def _seed_data(self):
+        async with self.session_factory() as session:
+            session.add_all(
+                [
+                    Stock(id=1, stock_code="600001", stock_name="Alpha", market="SH", is_st=0, is_kc=0, is_cy=0),
+                    Stock(id=2, stock_code="600002", stock_name="Beta", market="SH", is_st=0, is_kc=0, is_cy=0),
+                    Stock(id=3, stock_code="600003", stock_name="Gamma", market="SH", is_st=0, is_kc=0, is_cy=0),
+                    Stock(id=4, stock_code="600004", stock_name="Delta", market="SH", is_st=0, is_kc=0, is_cy=0),
+                    Stock(id=5, stock_code="600005", stock_name="Epsilon", market="SH", is_st=0, is_kc=0, is_cy=0),
+                    Stock(id=6, stock_code="600006", stock_name="Zeta", market="SH", is_st=0, is_kc=0, is_cy=0),
+                ]
+            )
+            session.add_all(
+                [
+                    MarketReviewDailyMetric(
+                        trade_date=date(2026, 4, 26),
+                        limit_up_count=3,
+                        limit_down_count=1,
+                        continuous_count=1,
+                        max_board_height=2,
+                        second_board_height=1,
+                        gem_board_height=0,
+                        first_to_second_rate=20.5,
+                        continuous_promotion_rate=33.3,
+                        seal_rate=70.0,
+                        yesterday_limit_up_avg_change=1.5,
+                        yesterday_continuous_avg_change=2.5,
+                        market_turnover=1000.0,
+                        up_count_ex_st=2100,
+                        down_count_ex_st=900,
+                        limit_up_amount=120.0,
+                        broken_amount=35.0,
+                    ),
+                    MarketReviewDailyMetric(
+                        trade_date=date(2026, 4, 27),
+                        limit_up_count=5,
+                        limit_down_count=2,
+                        continuous_count=2,
+                        max_board_height=3,
+                        second_board_height=2,
+                        gem_board_height=1,
+                        first_to_second_rate=25.0,
+                        continuous_promotion_rate=40.0,
+                        seal_rate=72.5,
+                        yesterday_limit_up_avg_change=1.8,
+                        yesterday_continuous_avg_change=3.2,
+                        market_turnover=1100.0,
+                        up_count_ex_st=2200,
+                        down_count_ex_st=880,
+                        limit_up_amount=150.0,
+                        broken_amount=45.0,
+                    ),
+                    MarketReviewDailyMetric(
+                        trade_date=date(2026, 4, 28),
+                        limit_up_count=8,
+                        limit_down_count=1,
+                        continuous_count=4,
+                        max_board_height=4,
+                        second_board_height=3,
+                        gem_board_height=2,
+                        first_to_second_rate=30.0,
+                        continuous_promotion_rate=50.0,
+                        seal_rate=78.8,
+                        yesterday_limit_up_avg_change=2.1,
+                        yesterday_continuous_avg_change=4.0,
+                        market_turnover=1250.0,
+                        up_count_ex_st=2300,
+                        down_count_ex_st=820,
+                        limit_up_amount=180.0,
+                        broken_amount=30.0,
+                    ),
+                ]
+            )
+            session.add_all(
+                [
+                    self._stock_row(1, "600001", "Alpha", 4, True, True, False, 7.1, 200000.0, "AI"),
+                    self._stock_row(2, "600002", "Beta", 4, True, True, False, 8.8, 300000.0, "Robotics"),
+                    self._stock_row(3, "600003", "Gamma", 3, True, False, True, 6.5, 400000.0, "Chip"),
+                    self._stock_row(4, "600004", "Delta", 2, False, False, True, 4.2, 50000.0, "EV"),
+                    self._stock_row(5, "600005", "Epsilon", 1, True, True, False, 2.5, 600000.0, "Retail"),
+                    self._stock_row(6, "600006", "Zeta", 2, True, True, False, 5.0, 250000.0, "Finance"),
+                ]
+            )
+            await session.commit()
+
+    def _stock_row(
+        self,
+        stock_id,
+        stock_code,
+        stock_name,
+        today_continuous_days,
+        today_touched_limit_up,
+        today_sealed_close,
+        today_opened_close,
+        change_pct,
+        amount,
+        limit_up_reason,
+    ):
+        return MarketReviewStockDaily(
+            trade_date=date(2026, 4, 28),
+            stock_id=stock_id,
+            stock_code=stock_code,
+            stock_name=stock_name,
+            board_type="main",
+            is_st=False,
+            yesterday_limit_up=today_continuous_days > 1,
+            yesterday_continuous_days=max(today_continuous_days - 1, 0),
+            today_touched_limit_up=today_touched_limit_up,
+            today_sealed_close=today_sealed_close,
+            today_opened_close=today_opened_close,
+            today_broken=today_opened_close,
+            today_continuous_days=today_continuous_days,
+            change_pct=change_pct,
+            amount=amount,
+            limit_up_reason=limit_up_reason,
+        )
+
+    def test_daily_endpoint_returns_filtered_rows_and_ascending_series(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/daily",
+            params={"start_date": "2026-04-27", "end_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["series"], ["2026-04-27", "2026-04-28"])
+
+        rows = payload["data"]["rows"]
+        self.assertEqual([row["trade_date"] for row in rows], ["2026-04-27", "2026-04-28"])
+        self.assertEqual(rows[0]["limit_up_count"], 5)
+        self.assertEqual(rows[1]["max_board_height"], 4)
+
+        for field in (
+            "trade_date",
+            "limit_up_count",
+            "limit_down_count",
+            "continuous_count",
+            "max_board_height",
+            "second_board_height",
+            "gem_board_height",
+            "first_to_second_rate",
+            "continuous_promotion_rate",
+            "seal_rate",
+            "yesterday_limit_up_avg_change",
+            "yesterday_continuous_avg_change",
+            "market_turnover",
+            "up_count_ex_st",
+            "down_count_ex_st",
+            "limit_up_amount",
+            "broken_amount",
+        ):
+            self.assertIn(field, rows[0])
+
+    def test_detail_endpoint_sorts_by_continuous_days_then_amount_desc(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/detail",
+            params={"trade_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(
+            [stock["stock_code"] for stock in payload["stocks"]],
+            ["600002", "600001", "600003", "600006", "600004", "600005"],
+        )
+        self.assertEqual(payload["stocks"][0]["limit_up_reason"], "Robotics")
+        self.assertEqual(payload["stocks"][2]["today_opened_close"], True)
+
+    def test_ladder_endpoint_groups_descending_and_filters_non_qualifying_stocks(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/ladder",
+            params={"trade_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(
+            [ladder["continuous_days"] for ladder in payload["ladders"]],
+            [4, 3, 2],
+        )
+        self.assertEqual(payload["ladders"][0]["count"], 2)
+        self.assertEqual(
+            [stock["stock_code"] for stock in payload["ladders"][0]["stocks"]],
+            ["600002", "600001"],
+        )
+        ladder_stock_codes = {
+            stock["stock_code"]
+            for ladder in payload["ladders"]
+            for stock in ladder["stocks"]
+        }
+        self.assertNotIn("600004", ladder_stock_codes)
+        self.assertNotIn("600005", ladder_stock_codes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -28,12 +28,16 @@ def _load_review_router():
 class MarketReviewApiTests(unittest.TestCase):
     def test_review_router_import_does_not_execute_api_v1_package(self):
         before_modules = set(sys.modules)
-        self.assertNotIn("app.api.v1", before_modules)
 
         _load_review_router()
 
-        after_modules = set(sys.modules)
-        self.assertNotIn("app.api.v1", after_modules - before_modules)
+        introduced_modules = set(sys.modules) - before_modules
+        self.assertFalse(
+            any(
+                module_name == "app.api.v1" or module_name.startswith("app.api.v1.")
+                for module_name in introduced_modules
+            )
+        )
 
     def setUp(self):
         self.engine = create_async_engine(

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -25,12 +25,15 @@ def _load_review_router():
     return module.router
 
 
-review_router = _load_review_router()
-
-
 class MarketReviewApiTests(unittest.TestCase):
     def test_review_router_import_does_not_execute_api_v1_package(self):
-        self.assertNotIn("app.api.v1", sys.modules)
+        before_modules = set(sys.modules)
+        self.assertNotIn("app.api.v1", before_modules)
+
+        _load_review_router()
+
+        after_modules = set(sys.modules)
+        self.assertNotIn("app.api.v1", after_modules - before_modules)
 
     def setUp(self):
         self.engine = create_async_engine(
@@ -45,6 +48,7 @@ class MarketReviewApiTests(unittest.TestCase):
         )
         asyncio.run(self._create_schema())
         asyncio.run(self._seed_data())
+        review_router = _load_review_router()
 
         self.app = FastAPI()
         self.app.include_router(review_router, prefix="/api/v1/statistics/review")

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from datetime import date
+from datetime import date, time
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
 import app.models  # noqa: F401
-from app.api.v1 import api_router
+from app.api.v1.review import router as review_router
 from app.database import Base, get_db
 from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockDaily
 from app.models.stock import Stock
@@ -30,7 +30,7 @@ class MarketReviewApiTests(unittest.TestCase):
         asyncio.run(self._seed_data())
 
         self.app = FastAPI()
-        self.app.include_router(api_router, prefix="/api/v1")
+        self.app.include_router(review_router, prefix="/api/v1/statistics/review")
 
         async def override_get_db():
             async with self.session_factory() as session:
@@ -123,12 +123,12 @@ class MarketReviewApiTests(unittest.TestCase):
             )
             session.add_all(
                 [
-                    self._stock_row(1, "600001", "Alpha", 4, True, True, False, 7.1, 200000.0, "AI"),
-                    self._stock_row(2, "600002", "Beta", 4, True, True, False, 8.8, 300000.0, "Robotics"),
-                    self._stock_row(3, "600003", "Gamma", 3, True, False, True, 6.5, 400000.0, "Chip"),
-                    self._stock_row(4, "600004", "Delta", 2, False, False, True, 4.2, 50000.0, "EV"),
-                    self._stock_row(5, "600005", "Epsilon", 1, True, True, False, 2.5, 600000.0, "Retail"),
-                    self._stock_row(6, "600006", "Zeta", 2, True, True, False, 5.0, 250000.0, "Finance"),
+                    self._stock_row(1, "600001", "Alpha", 4, True, True, False, 7.1, 200000.0, "AI", time(9, 31)),
+                    self._stock_row(2, "600002", "Beta", 4, True, False, True, 8.8, 300000.0, "Robotics", time(9, 29)),
+                    self._stock_row(3, "600003", "Gamma", 3, True, False, True, 6.5, 400000.0, "Chip", time(9, 45)),
+                    self._stock_row(4, "600004", "Delta", 2, False, False, True, 4.2, 50000.0, "EV", time(10, 5)),
+                    self._stock_row(5, "600005", "Epsilon", 1, True, True, False, 2.5, 600000.0, "Retail", time(9, 40)),
+                    self._stock_row(6, "600006", "Zeta", 2, True, True, False, 5.0, 250000.0, "Finance", time(9, 35)),
                 ]
             )
             await session.commit()
@@ -145,6 +145,7 @@ class MarketReviewApiTests(unittest.TestCase):
         change_pct,
         amount,
         limit_up_reason,
+        first_limit_time,
     ):
         return MarketReviewStockDaily(
             trade_date=date(2026, 4, 28),
@@ -160,6 +161,7 @@ class MarketReviewApiTests(unittest.TestCase):
             today_opened_close=today_opened_close,
             today_broken=today_opened_close,
             today_continuous_days=today_continuous_days,
+            first_limit_time=first_limit_time,
             change_pct=change_pct,
             amount=amount,
             limit_up_reason=limit_up_reason,
@@ -210,14 +212,27 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(payload["is_fallback"], False)
         self.assertEqual(
             [stock["stock_code"] for stock in payload["stocks"]],
             ["600002", "600001", "600003", "600006", "600004", "600005"],
         )
         self.assertEqual(payload["stocks"][0]["limit_up_reason"], "Robotics")
-        self.assertEqual(payload["stocks"][2]["today_opened_close"], True)
+        self.assertEqual(payload["stocks"][0]["today_opened_close"], True)
 
-    def test_ladder_endpoint_groups_descending_and_filters_non_qualifying_stocks(self):
+    def test_detail_endpoint_falls_back_to_latest_available_review_date(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/detail",
+            params={"trade_date": "2026-05-02"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(payload["is_fallback"], True)
+        self.assertEqual(payload["stocks"][0]["stock_code"], "600002")
+
+    def test_ladder_endpoint_groups_descending_filters_and_orders_sealed_before_opened(self):
         response = self.client.get(
             "/api/v1/statistics/review/ladder",
             params={"trade_date": "2026-04-28"},
@@ -226,6 +241,7 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(payload["is_fallback"], False)
         self.assertEqual(
             [ladder["continuous_days"] for ladder in payload["ladders"]],
             [4, 3, 2],
@@ -233,7 +249,7 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(payload["ladders"][0]["count"], 2)
         self.assertEqual(
             [stock["stock_code"] for stock in payload["ladders"][0]["stocks"]],
-            ["600002", "600001"],
+            ["600001", "600002"],
         )
         ladder_stock_codes = {
             stock["stock_code"]
@@ -242,6 +258,18 @@ class MarketReviewApiTests(unittest.TestCase):
         }
         self.assertNotIn("600004", ladder_stock_codes)
         self.assertNotIn("600005", ladder_stock_codes)
+
+    def test_ladder_endpoint_falls_back_to_latest_available_review_date(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/ladder",
+            params={"trade_date": "2026-05-02"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["trade_date"], "2026-04-28")
+        self.assertEqual(payload["is_fallback"], True)
+        self.assertEqual(payload["ladders"][0]["stocks"][0]["stock_code"], "600001")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -264,6 +264,21 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(payload["latest_trade_date"], "2026-04-28")
         self.assertTrue(payload["is_fallback"])
 
+    def test_daily_endpoint_days_returns_latest_available_trading_rows(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/daily",
+            params={"days": 2, "end_date": "2026-05-02"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["data"]["series"], ["2026-04-27", "2026-04-28"])
+        self.assertEqual(payload["start_date"], "2026-04-27")
+        self.assertEqual(payload["end_date"], "2026-04-28")
+        self.assertEqual(payload["requested_end_date"], "2026-05-02")
+        self.assertEqual(payload["latest_trade_date"], "2026-04-28")
+        self.assertTrue(payload["is_fallback"])
+
     def test_detail_endpoint_sorts_by_continuous_days_then_amount_desc(self):
         response = self.client.get(
             "/api/v1/statistics/review/detail",

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib.util
 import sys
 import unittest
-from datetime import date, time
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -421,6 +421,35 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(payload["is_fallback"], True)
         self.assertEqual(payload["ladders"][0]["stocks"][0]["stock_code"], "600001")
 
+    def test_live_intraday_detection_uses_trading_calendar_and_closes_at_market_end(self):
+        class MarketOpenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 5, 6, 14, 59, tzinfo=timezone(timedelta(hours=8)))
+
+        class MarketClosedDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 5, 6, 15, 1, tzinfo=timezone(timedelta(hours=8)))
+
+        original_datetime = self.review_module.datetime
+        try:
+            self.review_module._TRADING_DAY_CACHE.clear()
+            self.review_module._load_cn_trading_dates = Mock(return_value={date(2026, 5, 6)})
+            self.review_module.datetime = MarketOpenDatetime
+            self.assertTrue(self.review_module._should_collect_live_intraday(date(2026, 5, 6)))
+
+            self.review_module.datetime = MarketClosedDatetime
+            self.assertFalse(self.review_module._should_collect_live_intraday(date(2026, 5, 6)))
+
+            self.review_module._TRADING_DAY_CACHE.clear()
+            self.review_module._load_cn_trading_dates = Mock(return_value=set())
+            self.review_module.datetime = MarketOpenDatetime
+            self.assertFalse(self.review_module._should_collect_live_intraday(date(2026, 5, 6)))
+        finally:
+            self.review_module.datetime = original_datetime
+            self.review_module._TRADING_DAY_CACHE.clear()
+
     def test_intraday_endpoint_returns_live_metric_detail_and_ladder_snapshot(self):
         collect_mock = AsyncMock(
             return_value={
@@ -523,6 +552,7 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertTrue(payload["is_intraday"])
+        self.assertTrue(payload["is_live"])
         self.assertIsNotNone(payload["snapshot_time"])
         self.assertEqual(payload["data"]["series"], ["2026-05-06"])
         row = payload["data"]["rows"][0]
@@ -549,6 +579,7 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertTrue(payload["is_intraday"])
+        self.assertFalse(payload["is_live"])
         self.assertFalse(payload["is_fallback"])
         self.assertEqual(payload["data"]["series"], ["2026-04-28"])
         self.assertEqual(payload["data"]["rows"][0]["max_board_label"], "Alpha4\nBeta4")

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from datetime import date, time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 from fastapi import FastAPI
@@ -468,6 +469,24 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual([stock["stock_code"] for stock in payload["detail"]["stocks"]], ["600011", "600010", "600012"])
         self.assertEqual([ladder["continuous_days"] for ladder in payload["ladder"]["ladders"]], [3, 2])
         self.assertEqual(payload["ladder"]["ladders"][0]["count"], 2)
+
+    def test_intraday_source_wrapper_uses_market_review_source_service_collect_for_date(self):
+        service = SimpleNamespace(
+            collect_for_date=AsyncMock(return_value={"stock_rows": []})
+        )
+        module_name = "app.services.market_review_source_service"
+        original_module = sys.modules.get(module_name)
+        sys.modules[module_name] = SimpleNamespace(market_review_source_service=service)
+        try:
+            result = asyncio.run(self.review_module._collect_intraday_source(date(2026, 5, 6)))
+        finally:
+            if original_module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = original_module
+
+        self.assertEqual(result, {"stock_rows": []})
+        service.collect_for_date.assert_awaited_once_with(date(2026, 5, 6))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -153,7 +153,20 @@ class MarketReviewApiTests(unittest.TestCase):
                     self._stock_row(3, "600003", "Gamma", 3, True, False, True, 6.5, 400000.0, "Chip", time(9, 45)),
                     self._stock_row(4, "600004", "Delta", 2, False, False, True, 4.2, 50000.0, "EV", time(10, 5)),
                     self._stock_row(5, "600005", "Epsilon", 1, True, True, False, 2.5, 600000.0, "Retail", time(9, 40)),
-                    self._stock_row(6, "600006", "Zeta", 2, True, True, False, 5.0, 250000.0, "Finance", time(9, 35)),
+                    self._stock_row(
+                        6,
+                        "600006",
+                        "Zeta",
+                        2,
+                        True,
+                        True,
+                        False,
+                        5.0,
+                        250000.0,
+                        "Finance",
+                        time(9, 35),
+                        board_type="gem",
+                    ),
                 ]
             )
             await session.commit()
@@ -171,13 +184,14 @@ class MarketReviewApiTests(unittest.TestCase):
         amount,
         limit_up_reason,
         first_limit_time,
+        board_type="main",
     ):
         return MarketReviewStockDaily(
             trade_date=date(2026, 4, 28),
             stock_id=stock_id,
             stock_code=stock_code,
             stock_name=stock_name,
-            board_type="main",
+            board_type=board_type,
             is_st=False,
             yesterday_limit_up=today_continuous_days > 1,
             yesterday_continuous_days=max(today_continuous_days - 1, 0),
@@ -231,6 +245,18 @@ class MarketReviewApiTests(unittest.TestCase):
             "broken_amount",
         ):
             self.assertIn(field, rows[0])
+
+    def test_daily_endpoint_includes_board_height_stock_labels(self):
+        response = self.client.get(
+            "/api/v1/statistics/review/daily",
+            params={"start_date": "2026-04-28", "end_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        row = response.json()["data"]["rows"][0]
+        self.assertEqual(row["max_board_label"], "Alpha4\nBeta4")
+        self.assertEqual(row["second_board_label"], "Gamma3")
+        self.assertEqual(row["gem_board_label"], "Zeta2")
 
     def test_daily_endpoint_resolves_future_end_date_to_latest_available_metric(self):
         response = self.client.get(

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -449,6 +449,7 @@ class MarketReviewApiTests(unittest.TestCase):
         )
 
         self.review_module._collect_intraday_source = collect_mock
+        self.review_module._should_collect_live_intraday = Mock(return_value=True)
         if hasattr(self.review_module, "market_review_metrics_service"):
             self.review_module.market_review_metrics_service.aggregate_daily_metrics = aggregate_mock
 
@@ -469,6 +470,26 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual([stock["stock_code"] for stock in payload["detail"]["stocks"]], ["600011", "600010", "600012"])
         self.assertEqual([ladder["continuous_days"] for ladder in payload["ladder"]["ladders"]], [3, 2])
         self.assertEqual(payload["ladder"]["ladders"][0]["count"], 2)
+
+    def test_intraday_endpoint_uses_stored_review_snapshot_when_available(self):
+        self.review_module._collect_intraday_source = AsyncMock(
+            side_effect=AssertionError("stored intraday snapshot should not collect live source")
+        )
+
+        response = self.client.get(
+            "/api/v1/statistics/review/intraday",
+            params={"trade_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["is_intraday"])
+        self.assertFalse(payload["is_fallback"])
+        self.assertEqual(payload["data"]["series"], ["2026-04-28"])
+        self.assertEqual(payload["data"]["rows"][0]["max_board_label"], "Alpha4\nBeta4")
+        self.assertEqual(payload["detail"]["stocks"][0]["stock_code"], "600002")
+        self.assertEqual(payload["ladder"]["ladders"][0]["continuous_days"], 4)
+        self.review_module._collect_intraday_source.assert_not_awaited()
 
     def test_intraday_source_wrapper_uses_market_review_source_service_collect_for_date(self):
         service = SimpleNamespace(

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -367,6 +367,48 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertNotIn("600004", ladder_stock_codes)
         self.assertNotIn("600005", ladder_stock_codes)
 
+    def test_ladder_endpoint_metrics_include_unpromoted_same_cohort(self):
+        async def add_unpromoted_stock():
+            async with self.session_factory() as session:
+                session.add(
+                    MarketReviewStockDaily(
+                        trade_date=date(2026, 4, 28),
+                        stock_id=7,
+                        stock_code="600007",
+                        stock_name="Eta",
+                        board_type="main",
+                        is_st=False,
+                        yesterday_limit_up=True,
+                        yesterday_continuous_days=3,
+                        today_touched_limit_up=False,
+                        today_sealed_close=False,
+                        today_opened_close=False,
+                        today_broken=False,
+                        today_continuous_days=0,
+                        change_pct=-2.0,
+                        amount=100000.0,
+                        limit_up_reason="AI",
+                    )
+                )
+                await session.commit()
+
+        asyncio.run(add_unpromoted_stock())
+
+        response = self.client.get(
+            "/api/v1/statistics/review/ladder",
+            params={"trade_date": "2026-04-28"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        ladder = response.json()["ladders"][0]
+        self.assertEqual(ladder["continuous_days"], 4)
+        self.assertEqual(ladder["count"], 2)
+        self.assertEqual(ladder["cohort_count"], 3)
+        self.assertEqual(ladder["cohort_sealed_count"], 1)
+        self.assertEqual(ladder["cohort_opened_count"], 1)
+        self.assertAlmostEqual(ladder["cohort_seal_rate"], 33.33)
+        self.assertAlmostEqual(ladder["cohort_avg_change"], 4.63)
+
     def test_ladder_endpoint_falls_back_to_latest_available_review_date(self):
         response = self.client.get(
             "/api/v1/statistics/review/ladder",
@@ -390,6 +432,8 @@ class MarketReviewApiTests(unittest.TestCase):
                         "today_touched_limit_up": True,
                         "today_sealed_close": True,
                         "today_opened_close": False,
+                        "yesterday_limit_up": True,
+                        "yesterday_continuous_days": 2,
                         "today_continuous_days": 3,
                         "change_pct": 10.01,
                         "amount": 120000.0,
@@ -402,6 +446,8 @@ class MarketReviewApiTests(unittest.TestCase):
                         "today_touched_limit_up": True,
                         "today_sealed_close": False,
                         "today_opened_close": True,
+                        "yesterday_limit_up": True,
+                        "yesterday_continuous_days": 2,
                         "today_continuous_days": 3,
                         "change_pct": 7.2,
                         "amount": 220000.0,
@@ -414,10 +460,26 @@ class MarketReviewApiTests(unittest.TestCase):
                         "today_touched_limit_up": True,
                         "today_sealed_close": True,
                         "today_opened_close": False,
+                        "yesterday_limit_up": True,
+                        "yesterday_continuous_days": 1,
                         "today_continuous_days": 2,
                         "change_pct": 20.0,
                         "amount": 180000.0,
                         "limit_up_reason": "Chip",
+                    },
+                    {
+                        "stock_code": "600013",
+                        "stock_name": "LiveEta",
+                        "board_type": "main",
+                        "today_touched_limit_up": False,
+                        "today_sealed_close": False,
+                        "today_opened_close": False,
+                        "yesterday_limit_up": True,
+                        "yesterday_continuous_days": 2,
+                        "today_continuous_days": 0,
+                        "change_pct": -1.0,
+                        "amount": 90000.0,
+                        "limit_up_reason": "AI",
                     },
                 ],
                 "limit_down_count": 2,
@@ -467,9 +529,12 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(row["max_board_label"], "LiveAlpha3\nLiveBeta3")
         self.assertEqual(row["second_board_label"], "LiveGamma2")
         self.assertEqual(row["gem_board_label"], "LiveGamma2")
-        self.assertEqual([stock["stock_code"] for stock in payload["detail"]["stocks"]], ["600011", "600010", "600012"])
+        self.assertEqual([stock["stock_code"] for stock in payload["detail"]["stocks"]], ["600011", "600010", "600012", "600013"])
         self.assertEqual([ladder["continuous_days"] for ladder in payload["ladder"]["ladders"]], [3, 2])
         self.assertEqual(payload["ladder"]["ladders"][0]["count"], 2)
+        self.assertEqual(payload["ladder"]["ladders"][0]["cohort_count"], 3)
+        self.assertAlmostEqual(payload["ladder"]["ladders"][0]["cohort_seal_rate"], 33.33)
+        self.assertAlmostEqual(payload["ladder"]["ladders"][0]["cohort_avg_change"], 5.4)
 
     def test_intraday_endpoint_uses_stored_review_snapshot_when_available(self):
         self.review_module._collect_intraday_source = AsyncMock(

--- a/backend/tests/test_market_review_api.py
+++ b/backend/tests/test_market_review_api.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from datetime import date, time
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -16,13 +17,17 @@ from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockD
 from app.models.stock import Stock
 
 
-def _load_review_router():
+def _load_review_module():
     review_module_path = Path(__file__).resolve().parents[1] / "app" / "api" / "v1" / "review.py"
     spec = importlib.util.spec_from_file_location("isolated_market_review_router", review_module_path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
-    return module.router
+    return module
+
+
+def _load_review_router():
+    return _load_review_module().router
 
 
 class MarketReviewApiTests(unittest.TestCase):
@@ -52,10 +57,10 @@ class MarketReviewApiTests(unittest.TestCase):
         )
         asyncio.run(self._create_schema())
         asyncio.run(self._seed_data())
-        review_router = _load_review_router()
+        self.review_module = _load_review_module()
 
         self.app = FastAPI()
-        self.app.include_router(review_router, prefix="/api/v1/statistics/review")
+        self.app.include_router(self.review_module.router, prefix="/api/v1/statistics/review")
 
         async def override_get_db():
             async with self.session_factory() as session:
@@ -372,6 +377,97 @@ class MarketReviewApiTests(unittest.TestCase):
         self.assertEqual(payload["trade_date"], "2026-04-28")
         self.assertEqual(payload["is_fallback"], True)
         self.assertEqual(payload["ladders"][0]["stocks"][0]["stock_code"], "600001")
+
+    def test_intraday_endpoint_returns_live_metric_detail_and_ladder_snapshot(self):
+        collect_mock = AsyncMock(
+            return_value={
+                "stock_rows": [
+                    {
+                        "stock_code": "600010",
+                        "stock_name": "LiveAlpha",
+                        "board_type": "main",
+                        "today_touched_limit_up": True,
+                        "today_sealed_close": True,
+                        "today_opened_close": False,
+                        "today_continuous_days": 3,
+                        "change_pct": 10.01,
+                        "amount": 120000.0,
+                        "limit_up_reason": "AI",
+                    },
+                    {
+                        "stock_code": "600011",
+                        "stock_name": "LiveBeta",
+                        "board_type": "main",
+                        "today_touched_limit_up": True,
+                        "today_sealed_close": False,
+                        "today_opened_close": True,
+                        "today_continuous_days": 3,
+                        "change_pct": 7.2,
+                        "amount": 220000.0,
+                        "limit_up_reason": "AI",
+                    },
+                    {
+                        "stock_code": "600012",
+                        "stock_name": "LiveGamma",
+                        "board_type": "gem",
+                        "today_touched_limit_up": True,
+                        "today_sealed_close": True,
+                        "today_opened_close": False,
+                        "today_continuous_days": 2,
+                        "change_pct": 20.0,
+                        "amount": 180000.0,
+                        "limit_up_reason": "Chip",
+                    },
+                ],
+                "limit_down_count": 2,
+                "market_turnover": 9800.0,
+                "up_count_ex_st": 2600,
+                "down_count_ex_st": 1200,
+            }
+        )
+        aggregate_mock = Mock(
+            return_value={
+                "trade_date": date(2026, 5, 6),
+                "limit_up_count": 3,
+                "limit_down_count": 2,
+                "continuous_count": 3,
+                "max_board_height": 3,
+                "second_board_height": 2,
+                "gem_board_height": 2,
+                "first_to_second_rate": 42.0,
+                "continuous_promotion_rate": 55.0,
+                "seal_rate": 66.67,
+                "yesterday_limit_up_avg_change": 3.4,
+                "yesterday_continuous_avg_change": 5.6,
+                "market_turnover": 9800.0,
+                "up_count_ex_st": 2600,
+                "down_count_ex_st": 1200,
+                "limit_up_amount": 520000.0,
+                "broken_amount": 220000.0,
+            }
+        )
+
+        self.review_module._collect_intraday_source = collect_mock
+        if hasattr(self.review_module, "market_review_metrics_service"):
+            self.review_module.market_review_metrics_service.aggregate_daily_metrics = aggregate_mock
+
+        response = self.client.get(
+            "/api/v1/statistics/review/intraday",
+            params={"trade_date": "2026-05-06"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["is_intraday"])
+        self.assertIsNotNone(payload["snapshot_time"])
+        self.assertEqual(payload["data"]["series"], ["2026-05-06"])
+        row = payload["data"]["rows"][0]
+        self.assertEqual(row["max_board_label"], "LiveAlpha3\nLiveBeta3")
+        self.assertEqual(row["second_board_label"], "LiveGamma2")
+        self.assertEqual(row["gem_board_label"], "LiveGamma2")
+        self.assertEqual([stock["stock_code"] for stock in payload["detail"]["stocks"]], ["600011", "600010", "600012"])
+        self.assertEqual([ladder["continuous_days"] for ladder in payload["ladder"]["ladders"]], [3, 2])
+        self.assertEqual(payload["ladder"]["ladders"][0]["count"], 2)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_metrics_service.py
+++ b/backend/tests/test_market_review_metrics_service.py
@@ -106,6 +106,94 @@ class MarketReviewMetricsServiceTests(unittest.TestCase):
         self.assertEqual(metric["limit_up_amount"], 0.0)
         self.assertEqual(metric["broken_amount"], 0.0)
 
+    def test_aggregate_daily_metrics_treats_first_board_only_as_height_one(self):
+        rows = [
+            {
+                "stock_code": "600010",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": False,
+                "yesterday_continuous_days": 0,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 1,
+                "change_pct": 9.95,
+                "amount": 50000.0,
+            }
+        ]
+
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 27),
+            stock_rows=rows,
+            limit_down_count=0,
+            market_turnover=0,
+            up_count_ex_st=0,
+            down_count_ex_st=0,
+        )
+
+        self.assertEqual(metric["max_board_height"], 1)
+        self.assertEqual(metric["second_board_height"], 0)
+
+    def test_aggregate_daily_metrics_uses_second_distinct_board_height(self):
+        rows = [
+            {
+                "stock_code": "600011",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 2,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 3,
+                "change_pct": 10.0,
+                "amount": 10000.0,
+            },
+            {
+                "stock_code": "600012",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 3,
+                "change_pct": 10.0,
+                "amount": 20000.0,
+            },
+            {
+                "stock_code": "600013",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 0,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 2,
+                "change_pct": 10.0,
+                "amount": 30000.0,
+            },
+        ]
+
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 27),
+            stock_rows=rows,
+            limit_down_count=0,
+            market_turnover=0,
+            up_count_ex_st=0,
+            down_count_ex_st=0,
+        )
+
+        self.assertEqual(metric["max_board_height"], 3)
+        self.assertEqual(metric["second_board_height"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_market_review_metrics_service.py
+++ b/backend/tests/test_market_review_metrics_service.py
@@ -1,0 +1,111 @@
+import unittest
+from datetime import date
+
+from app.services.market_review_metrics_service import MarketReviewMetricsService
+
+
+class MarketReviewMetricsServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.service = MarketReviewMetricsService()
+
+    def test_aggregate_daily_metrics_builds_review_totals(self):
+        rows = [
+            {
+                "stock_code": "600001",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 2,
+                "change_pct": 10.0,
+                "amount": 120000.0,
+            },
+            {
+                "stock_code": "300001",
+                "board_type": "gem",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 2,
+                "today_touched_limit_up": True,
+                "today_sealed_close": False,
+                "today_opened_close": True,
+                "today_broken": False,
+                "today_continuous_days": 3,
+                "change_pct": 4.5,
+                "amount": 80000.0,
+            },
+            {
+                "stock_code": "600002",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": False,
+                "yesterday_continuous_days": 0,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_broken": True,
+                "today_continuous_days": 0,
+                "change_pct": -3.2,
+                "amount": 10000.0,
+            },
+        ]
+
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 27),
+            stock_rows=rows,
+            limit_down_count=5,
+            market_turnover=12345.6,
+            up_count_ex_st=3200,
+            down_count_ex_st=1800,
+        )
+
+        self.assertEqual(metric["trade_date"], date(2026, 4, 27))
+        self.assertEqual(metric["limit_up_count"], 2)
+        self.assertEqual(metric["continuous_count"], 2)
+        self.assertEqual(metric["max_board_height"], 3)
+        self.assertEqual(metric["second_board_height"], 2)
+        self.assertEqual(metric["gem_board_height"], 3)
+        self.assertAlmostEqual(metric["first_to_second_rate"], 100.0)
+        self.assertAlmostEqual(metric["continuous_promotion_rate"], 100.0)
+        self.assertAlmostEqual(metric["seal_rate"], 50.0)
+        self.assertAlmostEqual(metric["yesterday_limit_up_avg_change"], 7.25)
+        self.assertAlmostEqual(metric["yesterday_continuous_avg_change"], 4.5)
+        self.assertAlmostEqual(metric["market_turnover"], 12345.6)
+        self.assertEqual(metric["up_count_ex_st"], 3200)
+        self.assertEqual(metric["down_count_ex_st"], 1800)
+        self.assertAlmostEqual(metric["limit_up_amount"], 200000.0)
+        self.assertAlmostEqual(metric["broken_amount"], 80000.0)
+
+    def test_aggregate_daily_metrics_handles_empty_rows(self):
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 27),
+            stock_rows=[],
+            limit_down_count=0,
+            market_turnover=0,
+            up_count_ex_st=0,
+            down_count_ex_st=0,
+        )
+
+        self.assertEqual(metric["limit_up_count"], 0)
+        self.assertEqual(metric["continuous_count"], 0)
+        self.assertEqual(metric["max_board_height"], 0)
+        self.assertEqual(metric["second_board_height"], 0)
+        self.assertEqual(metric["gem_board_height"], 0)
+        self.assertEqual(metric["first_to_second_rate"], 0.0)
+        self.assertEqual(metric["continuous_promotion_rate"], 0.0)
+        self.assertEqual(metric["seal_rate"], 0.0)
+        self.assertEqual(metric["yesterday_limit_up_avg_change"], 0.0)
+        self.assertEqual(metric["yesterday_continuous_avg_change"], 0.0)
+        self.assertEqual(metric["market_turnover"], 0.0)
+        self.assertEqual(metric["up_count_ex_st"], 0)
+        self.assertEqual(metric["down_count_ex_st"], 0)
+        self.assertEqual(metric["limit_up_amount"], 0.0)
+        self.assertEqual(metric["broken_amount"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_metrics_service.py
+++ b/backend/tests/test_market_review_metrics_service.py
@@ -106,6 +106,70 @@ class MarketReviewMetricsServiceTests(unittest.TestCase):
         self.assertEqual(metric["limit_up_amount"], 0.0)
         self.assertEqual(metric["broken_amount"], 0.0)
 
+    def test_aggregate_daily_metrics_ignores_missing_feedback_change_pct(self):
+        rows = [
+            {
+                "stock_code": "600010",
+                "board_type": "main",
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_continuous_days": 0,
+                "change_pct": None,
+                "amount": 10000.0,
+            },
+            {
+                "stock_code": "600011",
+                "board_type": "main",
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_continuous_days": 0,
+                "change_pct": 10.0,
+                "amount": 10000.0,
+            },
+            {
+                "stock_code": "600012",
+                "board_type": "main",
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 2,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_continuous_days": 0,
+                "change_pct": 4.0,
+                "amount": 10000.0,
+            },
+            {
+                "stock_code": "600013",
+                "board_type": "main",
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 2,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_continuous_days": 0,
+                "change_pct": None,
+                "amount": 10000.0,
+            },
+        ]
+
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 28),
+            stock_rows=rows,
+            limit_down_count=0,
+            market_turnover=0,
+            up_count_ex_st=0,
+            down_count_ex_st=0,
+        )
+
+        self.assertAlmostEqual(metric["yesterday_limit_up_avg_change"], 7.0)
+        self.assertAlmostEqual(metric["yesterday_continuous_avg_change"], 4.0)
+
     def test_aggregate_daily_metrics_treats_first_board_only_as_height_one(self):
         rows = [
             {

--- a/backend/tests/test_market_review_models.py
+++ b/backend/tests/test_market_review_models.py
@@ -1,0 +1,15 @@
+import unittest
+
+from app.database import Base
+from app.models import market_review  # noqa: F401
+
+
+class MarketReviewModelTests(unittest.TestCase):
+    def test_market_review_tables_are_registered(self):
+        self.assertIn("market_review_daily_metric", Base.metadata.tables)
+        self.assertIn("market_review_stock_daily", Base.metadata.tables)
+        self.assertIn("market_review_limitup_event", Base.metadata.tables)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_models.py
+++ b/backend/tests/test_market_review_models.py
@@ -1,5 +1,7 @@
 import unittest
 
+from sqlalchemy import UniqueConstraint
+
 from app.database import Base
 import app.models  # noqa: F401
 
@@ -8,6 +10,16 @@ class MarketReviewModelTests(unittest.TestCase):
     def test_market_review_tables_are_registered(self):
         stock_daily = Base.metadata.tables["market_review_stock_daily"]
         limitup_event = Base.metadata.tables["market_review_limitup_event"]
+        stock_daily_uniques = {
+            tuple(constraint.columns.keys())
+            for constraint in stock_daily.constraints
+            if isinstance(constraint, UniqueConstraint)
+        }
+        limitup_event_uniques = {
+            tuple(constraint.columns.keys())
+            for constraint in limitup_event.constraints
+            if isinstance(constraint, UniqueConstraint)
+        }
 
         self.assertIn("market_review_daily_metric", Base.metadata.tables)
         self.assertIn("market_review_stock_daily", Base.metadata.tables)
@@ -22,6 +34,10 @@ class MarketReviewModelTests(unittest.TestCase):
             sorted(fk.target_fullname for fk in limitup_event.c.stock_id.foreign_keys),
             ["stocks.id"],
         )
+        self.assertIn(("trade_date", "stock_code"), stock_daily_uniques)
+        self.assertIn(("trade_date", "stock_code", "event_type", "event_seq"), limitup_event_uniques)
+        self.assertNotIn(("trade_date", "stock_id"), stock_daily_uniques)
+        self.assertNotIn(("trade_date", "stock_id", "event_type", "event_seq"), limitup_event_uniques)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_models.py
+++ b/backend/tests/test_market_review_models.py
@@ -1,14 +1,27 @@
 import unittest
 
 from app.database import Base
-from app.models import market_review  # noqa: F401
+import app.models  # noqa: F401
 
 
 class MarketReviewModelTests(unittest.TestCase):
     def test_market_review_tables_are_registered(self):
+        stock_daily = Base.metadata.tables["market_review_stock_daily"]
+        limitup_event = Base.metadata.tables["market_review_limitup_event"]
+
         self.assertIn("market_review_daily_metric", Base.metadata.tables)
         self.assertIn("market_review_stock_daily", Base.metadata.tables)
         self.assertIn("market_review_limitup_event", Base.metadata.tables)
+        self.assertIn("stock_id", stock_daily.c)
+        self.assertIn("stock_id", limitup_event.c)
+        self.assertEqual(
+            sorted(fk.target_fullname for fk in stock_daily.c.stock_id.foreign_keys),
+            ["stocks.id"],
+        )
+        self.assertEqual(
+            sorted(fk.target_fullname for fk in limitup_event.c.stock_id.foreign_keys),
+            ["stocks.id"],
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_models.py
+++ b/backend/tests/test_market_review_models.py
@@ -9,6 +9,7 @@ class MarketReviewModelTests(unittest.TestCase):
         self.assertIn("market_review_daily_metric", Base.metadata.tables)
         self.assertIn("market_review_stock_daily", Base.metadata.tables)
         self.assertIn("market_review_limitup_event", Base.metadata.tables)
+        self.assertIn("daily_analysis_records", Base.metadata.tables)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -170,7 +170,15 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("trade_date", normalized["event_rows"][0])
 
     async def test_build_payload_for_date_marks_default_placeholder_source_as_non_authoritative(self):
-        service = MarketReviewPipelineService()
+        service = MarketReviewPipelineService(
+            source_service=StubSourceService(
+                {
+                    "source_status": "placeholder",
+                    "stock_rows": [],
+                    "event_rows": [],
+                }
+            )
+        )
 
         payload = await service.build_payload_for_date(date(2026, 4, 28))
 
@@ -485,8 +493,19 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
             normalized=self._normalized_input(),
         )
 
+        placeholder_service = MarketReviewPipelineService(
+            session_factory=self.session_factory,
+            source_service=StubSourceService(
+                {
+                    "source_status": "placeholder",
+                    "stock_rows": [],
+                    "event_rows": [],
+                }
+            ),
+        )
+
         with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
-            await service.run_for_date(date(2026, 4, 28), calc_version=2)
+            await placeholder_service.run_for_date(date(2026, 4, 28), calc_version=2)
 
         async with self.session_factory() as session:
             metric = (

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -114,6 +114,11 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
             "source_status": "stubbed",
         }
 
+    def _normalized_input_without_authority(self):
+        normalized = self._normalized_input()
+        normalized.pop("is_authoritative")
+        return normalized
+
     async def test_build_payload_for_date_uses_supplied_normalized_input(self):
         normalized = self._normalized_input()
         service = MarketReviewPipelineService()
@@ -171,6 +176,17 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(payload["is_authoritative"])
         self.assertEqual(payload["source_status"], "placeholder")
+
+    async def test_build_payload_for_date_marks_caller_supplied_payload_without_authority_as_non_authoritative(self):
+        service = MarketReviewPipelineService()
+
+        payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=self._normalized_input_without_authority(),
+        )
+
+        self.assertFalse(payload["is_authoritative"])
+        self.assertEqual(payload["source_status"], "stubbed")
 
     async def test_persist_payload_upserts_metric_stock_and_event_rows(self):
         service = MarketReviewPipelineService(session_factory=self.session_factory)
@@ -411,6 +427,53 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
             await service.run_for_date(date(2026, 4, 28), calc_version=2)
+
+        async with self.session_factory() as session:
+            metric = (
+                await session.execute(
+                    select(MarketReviewDailyMetric).where(
+                        MarketReviewDailyMetric.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalar_one()
+            stock_rows = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(metric.calc_version, 1)
+        self.assertEqual(metric.source_status, "stubbed")
+        self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
+        self.assertEqual([row.stock_code for row in event_rows], ["600001"])
+
+    async def test_run_for_date_with_caller_payload_missing_authority_raises_and_preserves_existing_rows(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        await service.run_for_date(
+            date(2026, 4, 28),
+            calc_version=1,
+            normalized=self._normalized_input(),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
+            await service.run_for_date(
+                date(2026, 4, 28),
+                calc_version=2,
+                normalized={
+                    "source_status": "placeholder",
+                    "stock_rows": [],
+                    "event_rows": [],
+                },
+            )
 
         async with self.session_factory() as session:
             metric = (

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -67,6 +67,7 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
 
     def _normalized_input(self):
         return {
+            "is_authoritative": True,
             "stock_rows": [
                 {
                     "stock_id": 1,
@@ -137,6 +138,7 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["metric_row"]["up_count_ex_st"], 3000)
         self.assertEqual(payload["metric_row"]["down_count_ex_st"], 1200)
         self.assertEqual(payload["metric_row"]["source_status"], "stubbed")
+        self.assertTrue(payload["is_authoritative"])
 
     async def test_run_for_date_collects_from_source_service_when_normalized_not_supplied(self):
         normalized = self._normalized_input()
@@ -161,6 +163,14 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_payload["event_rows"][0]["trade_date"], date(2026, 4, 29))
         self.assertNotIn("trade_date", normalized["stock_rows"][0])
         self.assertNotIn("trade_date", normalized["event_rows"][0])
+
+    async def test_build_payload_for_date_marks_default_placeholder_source_as_non_authoritative(self):
+        service = MarketReviewPipelineService()
+
+        payload = await service.build_payload_for_date(date(2026, 4, 28))
+
+        self.assertFalse(payload["is_authoritative"])
+        self.assertEqual(payload["source_status"], "placeholder")
 
     async def test_persist_payload_upserts_metric_stock_and_event_rows(self):
         service = MarketReviewPipelineService(session_factory=self.session_factory)
@@ -342,6 +352,93 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
         self.assertEqual(stock_rows[0].stock_name, "Alpha Rebuilt")
         self.assertEqual(event_rows, [])
+
+    async def test_persist_payload_canonicalizes_row_trade_dates_to_authoritative_trade_date(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=self._normalized_input(),
+        )
+        payload["stock_rows"][0]["trade_date"] = date(2026, 4, 29)
+        payload["event_rows"][0]["trade_date"] = date(2026, 4, 30)
+
+        async with self.session_factory() as session:
+            await service.persist_payload(session, payload)
+            await session.commit()
+
+        async with self.session_factory() as session:
+            stock_rows_on_authoritative_date = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            stock_rows_on_drift_date = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 29)
+                    )
+                )
+            ).scalars().all()
+            event_rows_on_authoritative_date = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows_on_drift_date = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 30)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual([row.stock_code for row in stock_rows_on_authoritative_date], ["600001"])
+        self.assertEqual(stock_rows_on_drift_date, [])
+        self.assertEqual([row.stock_code for row in event_rows_on_authoritative_date], ["600001"])
+        self.assertEqual(event_rows_on_drift_date, [])
+
+    async def test_run_for_date_with_placeholder_source_raises_and_preserves_existing_rows(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        await service.run_for_date(
+            date(2026, 4, 28),
+            calc_version=1,
+            normalized=self._normalized_input(),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
+            await service.run_for_date(date(2026, 4, 28), calc_version=2)
+
+        async with self.session_factory() as session:
+            metric = (
+                await session.execute(
+                    select(MarketReviewDailyMetric).where(
+                        MarketReviewDailyMetric.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalar_one()
+            stock_rows = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(metric.calc_version, 1)
+        self.assertEqual(metric.source_status, "stubbed")
+        self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
+        self.assertEqual([row.stock_code for row in event_rows], ["600001"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -108,8 +108,14 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         payload = await service.build_payload_for_date(date(2026, 4, 28), normalized=normalized)
 
         self.assertEqual(payload["trade_date"], date(2026, 4, 28))
-        self.assertIs(payload["stock_rows"], normalized["stock_rows"])
-        self.assertIs(payload["event_rows"], normalized["event_rows"])
+        self.assertIsNot(payload["stock_rows"], normalized["stock_rows"])
+        self.assertIsNot(payload["event_rows"], normalized["event_rows"])
+        self.assertIsNot(payload["stock_rows"][0], normalized["stock_rows"][0])
+        self.assertIsNot(payload["event_rows"][0], normalized["event_rows"][0])
+        self.assertEqual(payload["stock_rows"][0]["trade_date"], date(2026, 4, 28))
+        self.assertEqual(payload["event_rows"][0]["trade_date"], date(2026, 4, 28))
+        self.assertNotIn("trade_date", normalized["stock_rows"][0])
+        self.assertNotIn("trade_date", normalized["event_rows"][0])
         self.assertEqual(payload["metric_row"]["trade_date"], date(2026, 4, 28))
         self.assertEqual(payload["metric_row"]["limit_up_count"], 1)
         self.assertEqual(payload["metric_row"]["limit_down_count"], 3)
@@ -129,6 +135,20 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(source_service.called_with, date(2026, 4, 28))
         self.assertEqual(payload["metric_row"]["source_status"], "stubbed")
+
+    async def test_build_payload_for_date_reusing_normalized_input_does_not_leak_first_trade_date(self):
+        normalized = self._normalized_input()
+        service = MarketReviewPipelineService()
+
+        first_payload = await service.build_payload_for_date(date(2026, 4, 28), normalized=normalized)
+        second_payload = await service.build_payload_for_date(date(2026, 4, 29), normalized=normalized)
+
+        self.assertEqual(first_payload["stock_rows"][0]["trade_date"], date(2026, 4, 28))
+        self.assertEqual(first_payload["event_rows"][0]["trade_date"], date(2026, 4, 28))
+        self.assertEqual(second_payload["stock_rows"][0]["trade_date"], date(2026, 4, 29))
+        self.assertEqual(second_payload["event_rows"][0]["trade_date"], date(2026, 4, 29))
+        self.assertNotIn("trade_date", normalized["stock_rows"][0])
+        self.assertNotIn("trade_date", normalized["event_rows"][0])
 
     async def test_persist_payload_upserts_metric_stock_and_event_rows(self):
         service = MarketReviewPipelineService(session_factory=self.session_factory)
@@ -158,6 +178,7 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         async with self.session_factory() as session:
             await service.persist_payload(session, first_payload)
             await service.persist_payload(session, second_payload)
+            await session.commit()
 
         async with self.session_factory() as session:
             metric_rows = (await session.execute(select(MarketReviewDailyMetric))).scalars().all()
@@ -190,6 +211,55 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(event_row.event_type, "seal")
         self.assertEqual(event_row.event_seq, 1)
         self.assertEqual(event_row.payload_json, {"note": "updated"})
+
+    async def test_persist_payload_upserts_heterogeneous_rows_and_leaves_commit_to_caller(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        first_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=self._normalized_input(),
+        )
+
+        updated_normalized = self._normalized_input()
+        updated_normalized["stock_rows"][0].pop("today_opened_close")
+        updated_normalized["stock_rows"][0]["today_broken"] = True
+        updated_normalized["stock_rows"][0]["amount"] = 321000.0
+        updated_normalized["stock_rows"][0]["turnover_rate"] = 18.88
+        updated_normalized["event_rows"][0]["payload_json"] = {"note": "updated without commit"}
+        second_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=updated_normalized,
+        )
+
+        async with self.session_factory() as session:
+            await service.persist_payload(session, first_payload)
+            self.assertTrue(session.in_transaction())
+            await service.persist_payload(session, second_payload)
+            self.assertTrue(session.in_transaction())
+            await session.commit()
+
+        async with self.session_factory() as session:
+            stock_row = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28),
+                        MarketReviewStockDaily.stock_code == "600001",
+                    )
+                )
+            ).scalar_one()
+            event_row = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28),
+                        MarketReviewLimitUpEvent.stock_code == "600001",
+                    )
+                )
+            ).scalar_one()
+
+        self.assertFalse(stock_row.today_opened_close)
+        self.assertTrue(stock_row.today_broken)
+        self.assertAlmostEqual(stock_row.amount, 321000.0)
+        self.assertAlmostEqual(stock_row.turnover_rate, 18.88)
+        self.assertEqual(event_row.payload_json, {"note": "updated without commit"})
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -417,6 +417,66 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([row.stock_code for row in event_rows_on_authoritative_date], ["600001"])
         self.assertEqual(event_rows_on_drift_date, [])
 
+    async def test_persist_payload_with_truthy_non_boolean_authority_raises_and_preserves_existing_rows(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        await service.run_for_date(
+            date(2026, 4, 28),
+            calc_version=1,
+            normalized=self._normalized_input(),
+        )
+
+        malformed_payload = {
+            "trade_date": date(2026, 4, 28),
+            "is_authoritative": "false",
+            "metric_row": {
+                "trade_date": date(2026, 4, 28),
+                "limit_up_count": 0,
+                "limit_down_count": 0,
+                "continuous_count": 0,
+                "max_board_height": 0,
+                "market_turnover": 0.0,
+                "up_count_ex_st": 0,
+                "down_count_ex_st": 0,
+                "source_status": "placeholder",
+                "calc_version": 2,
+            },
+            "stock_rows": [],
+            "event_rows": [],
+            "source_status": "placeholder",
+        }
+
+        async with self.session_factory() as session:
+            with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
+                await service.persist_payload(session, malformed_payload)
+
+        async with self.session_factory() as session:
+            metric = (
+                await session.execute(
+                    select(MarketReviewDailyMetric).where(
+                        MarketReviewDailyMetric.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalar_one()
+            stock_rows = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(metric.calc_version, 1)
+        self.assertEqual(metric.source_status, "stubbed")
+        self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
+        self.assertEqual([row.stock_code for row in event_rows], ["600001"])
+
     async def test_run_for_date_with_placeholder_source_raises_and_preserves_existing_rows(self):
         service = MarketReviewPipelineService(session_factory=self.session_factory)
         await service.run_for_date(

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from datetime import date, time
 
@@ -37,16 +38,27 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         )
 
         async with self.session_factory() as session:
-            session.add(
-                Stock(
-                    id=1,
-                    stock_code="600001",
-                    stock_name="Alpha",
-                    market="SH",
-                    is_st=0,
-                    is_kc=0,
-                    is_cy=0,
-                )
+            session.add_all(
+                [
+                    Stock(
+                        id=1,
+                        stock_code="600001",
+                        stock_name="Alpha",
+                        market="SH",
+                        is_st=0,
+                        is_kc=0,
+                        is_cy=0,
+                    ),
+                    Stock(
+                        id=2,
+                        stock_code="600002",
+                        stock_name="Beta",
+                        market="SH",
+                        is_st=0,
+                        is_kc=0,
+                        is_cy=0,
+                    ),
+                ]
             )
             await session.commit()
 
@@ -260,6 +272,76 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(stock_row.amount, 321000.0)
         self.assertAlmostEqual(stock_row.turnover_rate, 18.88)
         self.assertEqual(event_row.payload_json, {"note": "updated without commit"})
+
+    async def test_persist_payload_replaces_existing_trade_date_snapshot(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        first_normalized = self._normalized_input()
+        second_stock = copy.deepcopy(first_normalized["stock_rows"][0])
+        second_stock.update(
+            {
+                "stock_id": 2,
+                "stock_code": "600002",
+                "stock_name": "Beta",
+                "limit_up_reason": "Robotics",
+            }
+        )
+        second_event = copy.deepcopy(first_normalized["event_rows"][0])
+        second_event.update(
+            {
+                "stock_id": 2,
+                "stock_code": "600002",
+                "stock_name": "Beta",
+                "payload_json": {"note": "beta"},
+            }
+        )
+        first_normalized["stock_rows"].append(second_stock)
+        first_normalized["event_rows"].append(second_event)
+
+        second_normalized = self._normalized_input()
+        second_normalized["stock_rows"][0]["stock_name"] = "Alpha Rebuilt"
+        second_normalized["event_rows"] = []
+
+        first_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=first_normalized,
+        )
+        second_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=second_normalized,
+        )
+
+        async with self.session_factory() as session:
+            await service.persist_payload(session, first_payload)
+            await service.persist_payload(session, second_payload)
+            await session.commit()
+
+        async with self.session_factory() as session:
+            metric = (
+                await session.execute(
+                    select(MarketReviewDailyMetric).where(
+                        MarketReviewDailyMetric.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalar_one()
+            stock_rows = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(metric.limit_up_count, 1)
+        self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
+        self.assertEqual(stock_rows[0].stock_name, "Alpha Rebuilt")
+        self.assertEqual(event_rows, [])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -1,0 +1,196 @@
+import unittest
+from datetime import date, time
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models  # noqa: F401
+from app.database import Base
+from app.models.market_review import (
+    MarketReviewDailyMetric,
+    MarketReviewLimitUpEvent,
+    MarketReviewStockDaily,
+)
+from app.models.stock import Stock
+from app.services.market_review_pipeline_service import MarketReviewPipelineService
+
+
+class StubSourceService:
+    def __init__(self, normalized):
+        self.normalized = normalized
+        self.called_with = None
+
+    async def collect_for_date(self, trade_date):
+        self.called_with = trade_date
+        return self.normalized
+
+
+class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            expire_on_commit=False,
+        )
+
+        async with self.session_factory() as session:
+            session.add(
+                Stock(
+                    id=1,
+                    stock_code="600001",
+                    stock_name="Alpha",
+                    market="SH",
+                    is_st=0,
+                    is_kc=0,
+                    is_cy=0,
+                )
+            )
+            await session.commit()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    def _normalized_input(self):
+        return {
+            "stock_rows": [
+                {
+                    "stock_id": 1,
+                    "stock_code": "600001",
+                    "stock_name": "Alpha",
+                    "board_type": "main",
+                    "is_st": False,
+                    "yesterday_limit_up": True,
+                    "yesterday_continuous_days": 1,
+                    "today_touched_limit_up": True,
+                    "today_sealed_close": True,
+                    "today_opened_close": False,
+                    "today_broken": False,
+                    "today_continuous_days": 2,
+                    "first_limit_time": time(9, 31),
+                    "final_seal_time": time(14, 55),
+                    "open_count": 1,
+                    "close_price": 11.2,
+                    "pre_close": 10.18,
+                    "change_pct": 10.02,
+                    "amount": 123456.78,
+                    "turnover_rate": 12.34,
+                    "tradable_market_value": 456789000.0,
+                    "limit_up_reason": "AI",
+                    "data_quality_flag": "ok",
+                }
+            ],
+            "event_rows": [
+                {
+                    "stock_id": 1,
+                    "stock_code": "600001",
+                    "stock_name": "Alpha",
+                    "event_type": "seal",
+                    "event_time": time(9, 31),
+                    "event_seq": 1,
+                    "source_name": "stub",
+                    "payload_json": {"note": "initial"},
+                }
+            ],
+            "limit_down_count": 3,
+            "market_turnover": 8888.5,
+            "up_count_ex_st": 3000,
+            "down_count_ex_st": 1200,
+            "source_status": "stubbed",
+        }
+
+    async def test_build_payload_for_date_uses_supplied_normalized_input(self):
+        normalized = self._normalized_input()
+        service = MarketReviewPipelineService()
+
+        payload = await service.build_payload_for_date(date(2026, 4, 28), normalized=normalized)
+
+        self.assertEqual(payload["trade_date"], date(2026, 4, 28))
+        self.assertIs(payload["stock_rows"], normalized["stock_rows"])
+        self.assertIs(payload["event_rows"], normalized["event_rows"])
+        self.assertEqual(payload["metric_row"]["trade_date"], date(2026, 4, 28))
+        self.assertEqual(payload["metric_row"]["limit_up_count"], 1)
+        self.assertEqual(payload["metric_row"]["limit_down_count"], 3)
+        self.assertEqual(payload["metric_row"]["continuous_count"], 1)
+        self.assertEqual(payload["metric_row"]["max_board_height"], 2)
+        self.assertAlmostEqual(payload["metric_row"]["market_turnover"], 8888.5)
+        self.assertEqual(payload["metric_row"]["up_count_ex_st"], 3000)
+        self.assertEqual(payload["metric_row"]["down_count_ex_st"], 1200)
+        self.assertEqual(payload["metric_row"]["source_status"], "stubbed")
+
+    async def test_run_for_date_collects_from_source_service_when_normalized_not_supplied(self):
+        normalized = self._normalized_input()
+        source_service = StubSourceService(normalized)
+        service = MarketReviewPipelineService(source_service=source_service)
+
+        payload = await service.build_payload_for_date(date(2026, 4, 28))
+
+        self.assertEqual(source_service.called_with, date(2026, 4, 28))
+        self.assertEqual(payload["metric_row"]["source_status"], "stubbed")
+
+    async def test_persist_payload_upserts_metric_stock_and_event_rows(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        first_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=self._normalized_input(),
+        )
+
+        await service.run_for_date(date(2026, 4, 28), calc_version=7, normalized=self._normalized_input())
+
+        updated_normalized = self._normalized_input()
+        updated_normalized["stock_rows"][0]["stock_name"] = "Alpha Updated"
+        updated_normalized["stock_rows"][0]["today_opened_close"] = True
+        updated_normalized["stock_rows"][0]["today_broken"] = True
+        updated_normalized["stock_rows"][0]["amount"] = 223456.78
+        updated_normalized["event_rows"][0]["payload_json"] = {"note": "updated"}
+        updated_normalized["limit_down_count"] = 5
+        updated_normalized["market_turnover"] = 9999.9
+        updated_normalized["source_status"] = "refreshed"
+
+        second_payload = await service.build_payload_for_date(
+            date(2026, 4, 28),
+            normalized=updated_normalized,
+        )
+        second_payload["metric_row"]["calc_version"] = 8
+
+        async with self.session_factory() as session:
+            await service.persist_payload(session, first_payload)
+            await service.persist_payload(session, second_payload)
+
+        async with self.session_factory() as session:
+            metric_rows = (await session.execute(select(MarketReviewDailyMetric))).scalars().all()
+            stock_rows = (await session.execute(select(MarketReviewStockDaily))).scalars().all()
+            event_rows = (await session.execute(select(MarketReviewLimitUpEvent))).scalars().all()
+
+        self.assertEqual(len(metric_rows), 1)
+        self.assertEqual(len(stock_rows), 1)
+        self.assertEqual(len(event_rows), 1)
+
+        metric = metric_rows[0]
+        stock_row = stock_rows[0]
+        event_row = event_rows[0]
+
+        self.assertEqual(metric.trade_date, date(2026, 4, 28))
+        self.assertEqual(metric.limit_down_count, 5)
+        self.assertAlmostEqual(metric.market_turnover, 9999.9)
+        self.assertEqual(metric.calc_version, 8)
+        self.assertEqual(metric.source_status, "refreshed")
+
+        self.assertEqual(stock_row.stock_id, 1)
+        self.assertEqual(stock_row.stock_code, "600001")
+        self.assertEqual(stock_row.stock_name, "Alpha Updated")
+        self.assertTrue(stock_row.today_opened_close)
+        self.assertTrue(stock_row.today_broken)
+        self.assertAlmostEqual(stock_row.amount, 223456.78)
+
+        self.assertEqual(event_row.stock_id, 1)
+        self.assertEqual(event_row.stock_code, "600001")
+        self.assertEqual(event_row.event_type, "seal")
+        self.assertEqual(event_row.event_seq, 1)
+        self.assertEqual(event_row.payload_json, {"note": "updated"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_pipeline_service.py
+++ b/backend/tests/test_market_review_pipeline_service.py
@@ -503,6 +503,56 @@ class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
         self.assertEqual([row.stock_code for row in event_rows], ["600001"])
 
+    async def test_run_for_date_with_truthy_non_boolean_authority_raises_and_preserves_existing_rows(self):
+        service = MarketReviewPipelineService(session_factory=self.session_factory)
+        await service.run_for_date(
+            date(2026, 4, 28),
+            calc_version=1,
+            normalized=self._normalized_input(),
+        )
+
+        for malformed_authority in ("false", "0", 1):
+            with self.subTest(malformed_authority=malformed_authority):
+                with self.assertRaisesRegex(RuntimeError, "authoritative|placeholder|incomplete"):
+                    await service.run_for_date(
+                        date(2026, 4, 28),
+                        calc_version=2,
+                        normalized={
+                            "is_authoritative": malformed_authority,
+                            "source_status": "placeholder",
+                            "stock_rows": [],
+                            "event_rows": [],
+                        },
+                    )
+
+        async with self.session_factory() as session:
+            metric = (
+                await session.execute(
+                    select(MarketReviewDailyMetric).where(
+                        MarketReviewDailyMetric.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalar_one()
+            stock_rows = (
+                await session.execute(
+                    select(MarketReviewStockDaily).where(
+                        MarketReviewStockDaily.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+            event_rows = (
+                await session.execute(
+                    select(MarketReviewLimitUpEvent).where(
+                        MarketReviewLimitUpEvent.trade_date == date(2026, 4, 28)
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(metric.calc_version, 1)
+        self.assertEqual(metric.source_status, "stubbed")
+        self.assertEqual([row.stock_code for row in stock_rows], ["600001"])
+        self.assertEqual([row.stock_code for row in event_rows], ["600001"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_market_review_scheduler.py
+++ b/backend/tests/test_market_review_scheduler.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import date, timezone
+from datetime import date, timedelta, tzinfo
 import sys
 import types
 from unittest.mock import AsyncMock, patch
@@ -46,12 +46,27 @@ sys.modules.setdefault("apscheduler.triggers", triggers_module)
 sys.modules.setdefault("apscheduler.triggers.cron", cron_module)
 sys.modules.setdefault("apscheduler.triggers.interval", interval_module)
 
+
+class StubShanghaiTimezone(tzinfo):
+    zone = "Asia/Shanghai"
+
+    def utcoffset(self, dt):
+        return timedelta(hours=8)
+
+    def dst(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return self.zone
+
+
 pytz_module = types.ModuleType("pytz")
-pytz_module.timezone = lambda _: timezone.utc
+pytz_module.timezone = lambda _: StubShanghaiTimezone()
 sys.modules.setdefault("pytz", pytz_module)
 
-from app.data_collectors.scheduler import DataScheduler
+from app.data_collectors.scheduler import DataScheduler, _get_cn_trading_dates
 from app.utils.time_utils import CN_TZ
+from scripts.backfill_market_review import backfill_market_review
 
 
 class FakeScheduler:
@@ -100,8 +115,13 @@ class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
         job_ids = set(jobs_by_id)
         self.assertIn("market_review_build", job_ids)
         self.assertIn("market_review_repair", job_ids)
+        self.assertEqual(getattr(CN_TZ, "zone", None), "Asia/Shanghai")
         self.assertIs(jobs_by_id["market_review_build"]["trigger"].kwargs["timezone"], CN_TZ)
         self.assertIs(jobs_by_id["market_review_repair"]["trigger"].kwargs["timezone"], CN_TZ)
+        self.assertEqual(
+            getattr(jobs_by_id["market_review_build"]["trigger"].kwargs["timezone"], "zone", None),
+            "Asia/Shanghai",
+        )
 
     def test_start_skips_market_review_jobs_when_disabled(self):
         scheduler = self._create_scheduler()
@@ -173,6 +193,22 @@ class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
 
         run_for_date.assert_awaited_once_with(date(2026, 4, 27), calc_version=1)
 
+    async def test_build_market_review_propagates_calendar_lookup_failure(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            side_effect=RuntimeError("calendar unavailable"),
+            create=True,
+        ), patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            with self.assertRaisesRegex(RuntimeError, "calendar unavailable"):
+                await scheduler._build_market_review()
+
+        run_for_date.assert_not_awaited()
+
     async def test_repair_market_review_skips_pipeline_on_non_trading_day(self):
         scheduler = self._create_scheduler()
 
@@ -202,6 +238,45 @@ class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
             await scheduler._repair_market_review()
 
         run_for_date.assert_awaited_once_with(date(2026, 4, 28), calc_version=2)
+
+    async def test_repair_market_review_propagates_calendar_lookup_failure(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            side_effect=RuntimeError("calendar unavailable"),
+            create=True,
+        ), patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            with self.assertRaisesRegex(RuntimeError, "calendar unavailable"):
+                await scheduler._repair_market_review()
+
+        run_for_date.assert_not_awaited()
+
+    def test_get_cn_trading_dates_raises_when_calendar_schema_is_invalid(self):
+        class InvalidCalendar:
+            def __contains__(self, key):
+                return False
+
+        fake_akshare = types.SimpleNamespace(tool_trade_date_hist_sina=lambda: InvalidCalendar())
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with self.assertRaisesRegex(RuntimeError, "trade_date"):
+                _get_cn_trading_dates(date(2026, 4, 27), date(2026, 4, 28))
+
+
+class MarketReviewBackfillTests(unittest.IsolatedAsyncioTestCase):
+    async def test_backfill_market_review_propagates_calendar_lookup_failure(self):
+        with patch(
+            "scripts.backfill_market_review._get_cn_trading_dates",
+            side_effect=RuntimeError("calendar unavailable"),
+        ), patch("builtins.print") as print_mock:
+            with self.assertRaisesRegex(RuntimeError, "calendar unavailable"):
+                await backfill_market_review(date(2026, 4, 27), date(2026, 4, 28), calc_version=1)
+
+        print_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_scheduler.py
+++ b/backend/tests/test_market_review_scheduler.py
@@ -1,0 +1,166 @@
+import unittest
+from datetime import date, timezone
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+apscheduler_module = types.ModuleType("apscheduler")
+schedulers_module = types.ModuleType("apscheduler.schedulers")
+asyncio_module = types.ModuleType("apscheduler.schedulers.asyncio")
+triggers_module = types.ModuleType("apscheduler.triggers")
+cron_module = types.ModuleType("apscheduler.triggers.cron")
+interval_module = types.ModuleType("apscheduler.triggers.interval")
+
+
+class StubAsyncIOScheduler:
+    def add_job(self, *args, **kwargs):
+        return None
+
+    def start(self):
+        return None
+
+    def shutdown(self):
+        return None
+
+
+class StubCronTrigger:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class StubIntervalTrigger:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+asyncio_module.AsyncIOScheduler = StubAsyncIOScheduler
+cron_module.CronTrigger = StubCronTrigger
+interval_module.IntervalTrigger = StubIntervalTrigger
+
+sys.modules.setdefault("apscheduler", apscheduler_module)
+sys.modules.setdefault("apscheduler.schedulers", schedulers_module)
+sys.modules.setdefault("apscheduler.schedulers.asyncio", asyncio_module)
+sys.modules.setdefault("apscheduler.triggers", triggers_module)
+sys.modules.setdefault("apscheduler.triggers.cron", cron_module)
+sys.modules.setdefault("apscheduler.triggers.interval", interval_module)
+
+pytz_module = types.ModuleType("pytz")
+pytz_module.timezone = lambda _: timezone.utc
+sys.modules.setdefault("pytz", pytz_module)
+
+from app.data_collectors.scheduler import DataScheduler
+
+
+class FakeScheduler:
+    def __init__(self):
+        self.jobs = []
+        self.started = False
+        self.shutdown_called = False
+
+    def add_job(self, func, trigger, **kwargs):
+        self.jobs.append({
+            "func": func,
+            "trigger": trigger,
+            **kwargs,
+        })
+
+    def start(self):
+        self.started = True
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
+    def _create_scheduler(self):
+        scheduler = DataScheduler()
+        scheduler.scheduler = FakeScheduler()
+        return scheduler
+
+    def test_start_registers_market_review_jobs_when_enabled(self):
+        scheduler = self._create_scheduler()
+
+        with patch("app.data_collectors.scheduler.settings") as mock_settings:
+            mock_settings.L2_COLLECT_INTERVAL = 3
+            mock_settings.CRAWLER_INTERVAL_THS = 300
+            mock_settings.CRAWLER_INTERVAL_KPL = 600
+            mock_settings.MARKET_REVIEW_ENABLED = True
+            mock_settings.MARKET_REVIEW_BUILD_HOUR = 15
+            mock_settings.MARKET_REVIEW_BUILD_MINUTE = 5
+            mock_settings.MARKET_REVIEW_REPAIR_ENABLED = True
+            mock_settings.MARKET_REVIEW_REPAIR_HOUR = 20
+            mock_settings.MARKET_REVIEW_REPAIR_MINUTE = 15
+
+            scheduler.start()
+
+        job_ids = {job["id"] for job in scheduler.scheduler.jobs}
+        self.assertIn("market_review_build", job_ids)
+        self.assertIn("market_review_repair", job_ids)
+
+    def test_start_skips_market_review_jobs_when_disabled(self):
+        scheduler = self._create_scheduler()
+
+        with patch("app.data_collectors.scheduler.settings") as mock_settings:
+            mock_settings.L2_COLLECT_INTERVAL = 3
+            mock_settings.CRAWLER_INTERVAL_THS = 300
+            mock_settings.CRAWLER_INTERVAL_KPL = 600
+            mock_settings.MARKET_REVIEW_ENABLED = False
+            mock_settings.MARKET_REVIEW_BUILD_HOUR = 15
+            mock_settings.MARKET_REVIEW_BUILD_MINUTE = 5
+            mock_settings.MARKET_REVIEW_REPAIR_ENABLED = True
+            mock_settings.MARKET_REVIEW_REPAIR_HOUR = 20
+            mock_settings.MARKET_REVIEW_REPAIR_MINUTE = 15
+
+            scheduler.start()
+
+        job_ids = {job["id"] for job in scheduler.scheduler.jobs}
+        self.assertNotIn("market_review_build", job_ids)
+        self.assertNotIn("market_review_repair", job_ids)
+
+    def test_start_skips_market_review_repair_when_repair_disabled(self):
+        scheduler = self._create_scheduler()
+
+        with patch("app.data_collectors.scheduler.settings") as mock_settings:
+            mock_settings.L2_COLLECT_INTERVAL = 3
+            mock_settings.CRAWLER_INTERVAL_THS = 300
+            mock_settings.CRAWLER_INTERVAL_KPL = 600
+            mock_settings.MARKET_REVIEW_ENABLED = True
+            mock_settings.MARKET_REVIEW_BUILD_HOUR = 15
+            mock_settings.MARKET_REVIEW_BUILD_MINUTE = 5
+            mock_settings.MARKET_REVIEW_REPAIR_ENABLED = False
+            mock_settings.MARKET_REVIEW_REPAIR_HOUR = 20
+            mock_settings.MARKET_REVIEW_REPAIR_MINUTE = 15
+
+            scheduler.start()
+
+        job_ids = {job["id"] for job in scheduler.scheduler.jobs}
+        self.assertIn("market_review_build", job_ids)
+        self.assertNotIn("market_review_repair", job_ids)
+
+    async def test_build_market_review_runs_pipeline_with_calc_version_one(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            await scheduler._build_market_review()
+
+        run_for_date.assert_awaited_once_with(date.today(), calc_version=1)
+
+    async def test_repair_market_review_runs_pipeline_with_calc_version_two(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            await scheduler._repair_market_review()
+
+        run_for_date.assert_awaited_once_with(date.today(), calc_version=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_scheduler.py
+++ b/backend/tests/test_market_review_scheduler.py
@@ -51,6 +51,7 @@ pytz_module.timezone = lambda _: timezone.utc
 sys.modules.setdefault("pytz", pytz_module)
 
 from app.data_collectors.scheduler import DataScheduler
+from app.utils.time_utils import CN_TZ
 
 
 class FakeScheduler:
@@ -95,9 +96,12 @@ class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
 
             scheduler.start()
 
-        job_ids = {job["id"] for job in scheduler.scheduler.jobs}
+        jobs_by_id = {job["id"]: job for job in scheduler.scheduler.jobs}
+        job_ids = set(jobs_by_id)
         self.assertIn("market_review_build", job_ids)
         self.assertIn("market_review_repair", job_ids)
+        self.assertIs(jobs_by_id["market_review_build"]["trigger"].kwargs["timezone"], CN_TZ)
+        self.assertIs(jobs_by_id["market_review_repair"]["trigger"].kwargs["timezone"], CN_TZ)
 
     def test_start_skips_market_review_jobs_when_disabled(self):
         scheduler = self._create_scheduler()
@@ -139,27 +143,65 @@ class MarketReviewSchedulerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("market_review_build", job_ids)
         self.assertNotIn("market_review_repair", job_ids)
 
-    async def test_build_market_review_runs_pipeline_with_calc_version_one(self):
+    async def test_build_market_review_skips_pipeline_on_non_trading_day(self):
         scheduler = self._create_scheduler()
 
         with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            return_value=None,
+            create=True,
+        ), patch(
             "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
             AsyncMock(),
         ) as run_for_date:
             await scheduler._build_market_review()
 
-        run_for_date.assert_awaited_once_with(date.today(), calc_version=1)
+        run_for_date.assert_not_awaited()
 
-    async def test_repair_market_review_runs_pipeline_with_calc_version_two(self):
+    async def test_build_market_review_runs_pipeline_with_calc_version_one(self):
         scheduler = self._create_scheduler()
 
         with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            return_value=date(2026, 4, 27),
+            create=True,
+        ), patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            await scheduler._build_market_review()
+
+        run_for_date.assert_awaited_once_with(date(2026, 4, 27), calc_version=1)
+
+    async def test_repair_market_review_skips_pipeline_on_non_trading_day(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            return_value=None,
+            create=True,
+        ), patch(
             "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
             AsyncMock(),
         ) as run_for_date:
             await scheduler._repair_market_review()
 
-        run_for_date.assert_awaited_once_with(date.today(), calc_version=2)
+        run_for_date.assert_not_awaited()
+
+    async def test_repair_market_review_runs_pipeline_with_calc_version_two(self):
+        scheduler = self._create_scheduler()
+
+        with patch(
+            "app.data_collectors.scheduler._resolve_cn_trade_date_for_market_review",
+            return_value=date(2026, 4, 28),
+            create=True,
+        ), patch(
+            "app.data_collectors.scheduler.market_review_pipeline_service.run_for_date",
+            AsyncMock(),
+        ) as run_for_date:
+            await scheduler._repair_market_review()
+
+        run_for_date.assert_awaited_once_with(date(2026, 4, 28), calc_version=2)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_market_review_source_service.py
+++ b/backend/tests/test_market_review_source_service.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import date, datetime
 
+import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -164,6 +165,57 @@ class MarketReviewSourceServiceTests(unittest.IsolatedAsyncioTestCase):
             ).scalars().all()
 
         self.assertEqual(stock_codes, ["600001", "600002"])
+
+    async def test_historical_market_stats_are_loaded_when_daily_statistics_are_missing(self):
+        called = {}
+
+        class HistoricalStatsService(MarketReviewSourceService):
+            def _fetch_historical_market_stats_sync(self, trade_date):
+                called["trade_date"] = trade_date
+                return {
+                    "limit_down_count": 20,
+                    "market_turnover": 26419.0,
+                    "up_count_ex_st": 1994,
+                    "down_count_ex_st": 3085,
+                }
+
+        service = HistoricalStatsService(
+            session_factory=self.session_factory,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        stats = await service._fetch_market_stats(date(2026, 4, 24))
+
+        self.assertEqual(
+            stats,
+            {
+                "limit_down_count": 20,
+                "market_turnover": 26419.0,
+                "up_count_ex_st": 1994,
+                "down_count_ex_st": 3085,
+            },
+        )
+        self.assertEqual(called["trade_date"], date(2026, 4, 24))
+
+    def test_extract_exchange_market_turnover_normalizes_sse_and_szse_units(self):
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+        sse_df = pd.DataFrame(
+            [
+                {"单日情况": "成交金额", "股票": 11274.75},
+            ]
+        )
+        szse_df = pd.DataFrame(
+            [
+                {"证券类别": "股票", "成交金额": 1465264000000.0},
+            ]
+        )
+
+        turnover = service._extract_exchange_market_turnover(sse_df, szse_df)
+
+        self.assertAlmostEqual(turnover, 25927.39)
 
     async def test_collect_for_date_returns_placeholder_when_all_sources_are_empty(self):
         async def empty_fetcher(_trade_date):

--- a/backend/tests/test_market_review_source_service.py
+++ b/backend/tests/test_market_review_source_service.py
@@ -1,0 +1,245 @@
+import unittest
+from datetime import date, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import app.models  # noqa: F401
+from app.database import Base
+from app.models.stock import Stock
+from app.services.market_review_source_service import MarketReviewSourceService
+
+
+class MarketReviewSourceServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            expire_on_commit=False,
+        )
+
+        async with self.session_factory() as session:
+            session.add(
+                Stock(
+                    stock_code="600001",
+                    stock_name="Alpha",
+                    market="SH",
+                    is_st=0,
+                    is_kc=0,
+                    is_cy=0,
+                )
+            )
+            await session.commit()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def test_collect_for_date_builds_authoritative_payload_from_market_sources(self):
+        async def today_fetcher(trade_date):
+            self.assertEqual(trade_date, date(2026, 4, 29))
+            return [
+                {
+                    "stock_code": "600001",
+                    "stock_name": "Alpha",
+                    "continuous_limit_up_days": 2,
+                    "is_sealed": False,
+                    "first_limit_up_time": datetime(2026, 4, 29, 9, 31, 0),
+                    "open_count": 1,
+                    "current_price": 11.0,
+                    "change_pct": 10.0,
+                    "amount": 123456.0,
+                    "turnover_rate": 12.3,
+                    "tradable_market_value": 456789.0,
+                    "limit_up_reason": "AI",
+                    "data_source": "RT",
+                }
+            ]
+
+        async def yesterday_pool_fetcher(trade_date):
+            self.assertEqual(trade_date, date(2026, 4, 29))
+            return [
+                {
+                    "c": "600001",
+                    "n": "Alpha",
+                    "ylbc": 1,
+                    "zdp": 10.0,
+                },
+                {
+                    "c": "600002",
+                    "n": "Beta",
+                    "ylbc": 2,
+                    "zdp": -3.2,
+                },
+            ]
+
+        async def quote_fetcher(codes):
+            self.assertEqual(set(codes), {"600001", "600002"})
+            return {
+                "600001": {
+                    "code": "600001",
+                    "name": "Alpha",
+                    "price": 11.0,
+                    "pre_close": 10.0,
+                    "change_pct": 10.0,
+                    "amount": 123456.0,
+                    "turnover_rate": 12.3,
+                },
+                "600002": {
+                    "code": "600002",
+                    "name": "Beta",
+                    "price": 8.8,
+                    "pre_close": 9.09,
+                    "change_pct": -3.2,
+                    "amount": 654321.0,
+                    "turnover_rate": 5.6,
+                },
+            }
+
+        async def market_stats_fetcher(trade_date):
+            self.assertEqual(trade_date, date(2026, 4, 29))
+            return {
+                "limit_down_count": 4,
+                "market_turnover": 9876.5,
+                "up_count_ex_st": 3000,
+                "down_count_ex_st": 1200,
+            }
+
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            today_limit_up_fetcher=today_fetcher,
+            yesterday_pool_fetcher=yesterday_pool_fetcher,
+            quote_fetcher=quote_fetcher,
+            market_stats_fetcher=market_stats_fetcher,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        payload = await service.collect_for_date(date(2026, 4, 29))
+
+        self.assertTrue(payload["is_authoritative"])
+        self.assertEqual(payload["source_status"], "primary")
+        self.assertEqual(payload["limit_down_count"], 4)
+        self.assertAlmostEqual(payload["market_turnover"], 9876.5)
+        self.assertEqual(payload["up_count_ex_st"], 3000)
+        self.assertEqual(payload["down_count_ex_st"], 1200)
+
+        rows_by_code = {row["stock_code"]: row for row in payload["stock_rows"]}
+        self.assertEqual(set(rows_by_code), {"600001", "600002"})
+
+        alpha = rows_by_code["600001"]
+        self.assertTrue(alpha["yesterday_limit_up"])
+        self.assertEqual(alpha["yesterday_continuous_days"], 1)
+        self.assertTrue(alpha["today_touched_limit_up"])
+        self.assertFalse(alpha["today_sealed_close"])
+        self.assertTrue(alpha["today_opened_close"])
+        self.assertTrue(alpha["today_broken"])
+        self.assertEqual(alpha["today_continuous_days"], 2)
+        self.assertAlmostEqual(alpha["change_pct"], 10.0)
+        self.assertEqual(alpha["limit_up_reason"], "AI")
+        self.assertIsNotNone(alpha["stock_id"])
+
+        beta = rows_by_code["600002"]
+        self.assertTrue(beta["yesterday_limit_up"])
+        self.assertEqual(beta["yesterday_continuous_days"], 2)
+        self.assertFalse(beta["today_touched_limit_up"])
+        self.assertEqual(beta["today_continuous_days"], 0)
+        self.assertAlmostEqual(beta["change_pct"], -3.2)
+        self.assertAlmostEqual(beta["amount"], 654321.0)
+        self.assertIsNotNone(beta["stock_id"])
+
+        event_keys = {
+            (row["stock_code"], row["event_type"])
+            for row in payload["event_rows"]
+        }
+        self.assertIn(("600001", "first_seal"), event_keys)
+        self.assertIn(("600001", "close_opened"), event_keys)
+
+        async with self.session_factory() as session:
+            stock_codes = (
+                await session.execute(
+                    select(Stock.stock_code).order_by(Stock.stock_code.asc())
+                )
+            ).scalars().all()
+
+        self.assertEqual(stock_codes, ["600001", "600002"])
+
+    async def test_collect_for_date_returns_placeholder_when_all_sources_are_empty(self):
+        async def empty_fetcher(_trade_date):
+            return []
+
+        async def empty_quotes(_codes):
+            return {}
+
+        async def empty_market_stats(_trade_date):
+            return {}
+
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            today_limit_up_fetcher=empty_fetcher,
+            yesterday_pool_fetcher=empty_fetcher,
+            quote_fetcher=empty_quotes,
+            market_stats_fetcher=empty_market_stats,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        payload = await service.collect_for_date(date(2026, 4, 28))
+
+        self.assertFalse(payload["is_authoritative"])
+        self.assertEqual(payload["source_status"], "placeholder")
+        self.assertEqual(payload["stock_rows"], [])
+        self.assertEqual(payload["event_rows"], [])
+
+    async def test_collect_for_date_fails_safe_when_today_source_failed_but_yesterday_pool_is_non_empty(self):
+        async def failed_today_fetcher(_trade_date):
+            return {
+                "items": [],
+                "succeeded": False,
+            }
+
+        async def yesterday_pool_fetcher(_trade_date):
+            return [
+                {
+                    "c": "600002",
+                    "n": "Beta",
+                    "ylbc": 2,
+                    "zdp": -3.2,
+                }
+            ]
+
+        async def empty_quotes(_codes):
+            return {}
+
+        async def empty_market_stats(_trade_date):
+            return {}
+
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            today_limit_up_fetcher=failed_today_fetcher,
+            yesterday_pool_fetcher=yesterday_pool_fetcher,
+            quote_fetcher=empty_quotes,
+            market_stats_fetcher=empty_market_stats,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        payload = await service.collect_for_date(date(2026, 4, 28))
+
+        self.assertFalse(payload["is_authoritative"])
+        self.assertEqual(payload["source_status"], "placeholder")
+        self.assertEqual(payload["stock_rows"], [])
+        self.assertEqual(payload["event_rows"], [])
+
+    async def test_bj_limit_helpers_use_thirty_percent_board_rules(self):
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        self.assertAlmostEqual(service._limit_ratio("830001", "北交样本"), 0.30)
+        self.assertTrue(service._is_limit_down(-29.6, "830001", "北交样本"))
+        self.assertFalse(service._is_limit_down(-19.8, "830001", "北交样本"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_market_review_source_service.py
+++ b/backend/tests/test_market_review_source_service.py
@@ -217,6 +217,40 @@ class MarketReviewSourceServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertAlmostEqual(turnover, 25927.39)
 
+    def test_parse_tencent_stock_history_stats_counts_moves_from_previous_close(self):
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+        rows = [
+            ["2026-04-23", "9.80", "10.00", "10.10", "9.70", "1000"],
+            ["2026-04-24", "10.00", "11.00", "11.00", "9.90", "2000"],
+            ["2026-04-27", "11.00", "9.90", "11.10", "9.80", "3000"],
+        ]
+
+        stats = service._parse_tencent_stock_history_stats(
+            stock_code="600001",
+            stock_name="Alpha",
+            rows=rows,
+            count_start_date=date(2026, 4, 24),
+        )
+
+        self.assertEqual(
+            stats,
+            {
+                date(2026, 4, 24): {
+                    "limit_down_count": 0,
+                    "up_count_ex_st": 1,
+                    "down_count_ex_st": 0,
+                },
+                date(2026, 4, 27): {
+                    "limit_down_count": 1,
+                    "up_count_ex_st": 0,
+                    "down_count_ex_st": 1,
+                },
+            },
+        )
+
     async def test_collect_for_date_returns_placeholder_when_all_sources_are_empty(self):
         async def empty_fetcher(_trade_date):
             return []

--- a/backend/tests/test_market_review_source_service.py
+++ b/backend/tests/test_market_review_source_service.py
@@ -316,6 +316,51 @@ class MarketReviewSourceServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["stock_rows"], [])
         self.assertEqual(payload["event_rows"], [])
 
+    async def test_collect_for_date_drops_yesterday_pool_sentinel_change_pct(self):
+        async def empty_today_fetcher(_trade_date):
+            return []
+
+        async def yesterday_pool_fetcher(_trade_date):
+            return [
+                {
+                    "c": "603272",
+                    "n": "联翔股份",
+                    "ylbc": 2,
+                    "zdp": -100.0,
+                    "p": 0,
+                    "amount": 0,
+                    "ltsz": 0.0,
+                }
+            ]
+
+        async def empty_quotes(_codes):
+            return {}
+
+        async def market_stats_fetcher(_trade_date):
+            return {
+                "limit_down_count": 0,
+                "market_turnover": 1000.0,
+                "up_count_ex_st": 100,
+                "down_count_ex_st": 100,
+            }
+
+        service = MarketReviewSourceService(
+            session_factory=self.session_factory,
+            today_limit_up_fetcher=empty_today_fetcher,
+            yesterday_pool_fetcher=yesterday_pool_fetcher,
+            quote_fetcher=empty_quotes,
+            market_stats_fetcher=market_stats_fetcher,
+            current_date_provider=lambda: date(2026, 4, 29),
+        )
+
+        payload = await service.collect_for_date(date(2026, 4, 28))
+
+        self.assertTrue(payload["is_authoritative"])
+        self.assertEqual(len(payload["stock_rows"]), 1)
+        row = payload["stock_rows"][0]
+        self.assertEqual(row["stock_code"], "603272")
+        self.assertIsNone(row["change_pct"])
+
     async def test_bj_limit_helpers_use_thirty_percent_board_rules(self):
         service = MarketReviewSourceService(
             session_factory=self.session_factory,

--- a/backend/tests/test_realtime_limit_up_service.py
+++ b/backend/tests/test_realtime_limit_up_service.py
@@ -155,6 +155,50 @@ class RealtimeLimitUpServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(data[0]["tradable_market_value"])
 
+    async def test_get_realtime_limit_up_list_drops_quote_sentinel_change_pct(self):
+        service = RealtimeLimitUpService()
+        service.get_fast_limit_up_pool = AsyncMock(
+            return_value=[
+                {
+                    "stock_code": "603272",
+                    "stock_name": "联翔股份",
+                    "continuous_limit_up_days": 2,
+                    "open_count": 0,
+                    "is_final_sealed": True,
+                    "limit_up_price": 26.73,
+                    "turnover_rate": 0,
+                    "amount": 0,
+                }
+            ]
+        )
+        service._fetch_ths_reason_map = AsyncMock(return_value={})
+
+        quotes = {
+            "603272": {
+                "code": "603272",
+                "price": 0,
+                "amount": 0,
+                "turnover_rate": 0,
+                "change_pct": -100.0,
+                "bid1_volume": 0,
+            }
+        }
+
+        with patch(
+            "app.services.realtime_limit_up_service.tencent_api.get_quotes_batch",
+            AsyncMock(return_value=quotes),
+        ), patch.object(
+            realtime_limit_up_module,
+            "tradable_market_value_service",
+            AsyncMock(),
+            create=True,
+        ) as tradable_market_value_service:
+            tradable_market_value_service.get_float_share_map = AsyncMock(return_value={})
+            data = await service.get_realtime_limit_up_list(date(2026, 4, 28))
+
+        self.assertEqual(data[0]["current_price"], 26.73)
+        self.assertIsNone(data[0]["change_pct"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/superpowers/plans/2026-04-27-market-review-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-market-review-implementation.md
@@ -1,0 +1,1338 @@
+# Market Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an end-of-day market review data warehouse and reporting flow that produces stable review metrics, supports historical backfill, and powers the frontend review charts without realtime recomputation.
+
+**Architecture:** Add three backend persistence tables for daily metrics, per-stock review facts, and limit-up events; implement one pure aggregation service plus one orchestration pipeline; expose dedicated `/statistics/review/*` APIs; then refactor the existing statistics page to read only the new aggregated endpoints.
+
+**Tech Stack:** FastAPI, SQLAlchemy async ORM, aiosqlite/SQLite, APScheduler, httpx, AKShare, Vue 3, Axios, ECharts, unittest
+
+---
+
+## File Structure
+
+### Backend files to create
+
+- `backend/app/models/market_review.py`
+  - ORM tables for `market_review_daily_metric`, `market_review_stock_daily`, `market_review_limitup_event`
+- `backend/app/schemas/market_review.py`
+  - Pydantic response models for review trend, detail, ladder, and point-in-time metric payloads
+- `backend/app/services/market_review_metrics_service.py`
+  - Pure aggregation logic that turns per-stock facts into daily review metrics
+- `backend/app/services/market_review_source_service.py`
+  - External data normalization for market turnover, breadth, limit-down list, and fallback history
+- `backend/app/services/market_review_pipeline_service.py`
+  - Orchestration service that collects source data, upserts fact rows, builds daily metrics, and reruns nightly repair
+- `backend/app/api/v1/review.py`
+  - Dedicated review API endpoints under `/statistics/review/*`
+- `backend/scripts/backfill_market_review.py`
+  - Manual historical backfill entry point
+- `backend/tests/test_market_review_models.py`
+  - Table registration and uniqueness coverage
+- `backend/tests/test_market_review_metrics_service.py`
+  - Pure metric aggregation coverage
+- `backend/tests/test_market_review_pipeline_service.py`
+  - Persistence and upsert coverage
+- `backend/tests/test_market_review_scheduler.py`
+  - Scheduler job registration and invocation coverage
+- `backend/tests/test_market_review_api.py`
+  - Review endpoint response coverage
+
+### Backend files to modify
+
+- `backend/requirements.txt`
+  - Add `akshare`
+- `backend/app/config.py`
+  - Add review job switches and repair timing configuration
+- `backend/app/models/__init__.py`
+  - Export new review models if package exports are used later
+- `backend/app/api/v1/__init__.py`
+  - Register the new review router under `/statistics/review`
+- `backend/app/data_collectors/scheduler.py`
+  - Schedule first-pass build and nightly repair jobs
+- `backend/app/main.py`
+  - Keep startup wiring unchanged except for review scheduler start/stop integration if needed
+- `frontend/src/api/index.ts`
+  - Re-export review API helpers
+- `frontend/src/types/market.ts`
+  - Add review-specific TS types
+- `frontend/src/views/Statistics.vue`
+  - Replace current lightweight charts with review-driven charts
+
+### Frontend files to create
+
+- `frontend/src/api/review.ts`
+  - Axios wrappers for `/statistics/review/daily`, `/statistics/review/detail`, `/statistics/review/ladder`
+
+## Task 1: Add Review Data Model and Config Surface
+
+**Files:**
+- Create: `backend/app/models/market_review.py`
+- Modify: `backend/app/models/__init__.py`
+- Modify: `backend/app/config.py`
+- Modify: `backend/requirements.txt`
+- Test: `backend/tests/test_market_review_models.py`
+
+- [ ] **Step 1: Write the failing model-registration test**
+
+```python
+import unittest
+
+from app.database import Base
+from app.models import market_review  # noqa: F401
+
+
+class MarketReviewModelTests(unittest.TestCase):
+    def test_review_tables_are_registered(self):
+        table_names = set(Base.metadata.tables.keys())
+        self.assertIn("market_review_daily_metric", table_names)
+        self.assertIn("market_review_stock_daily", table_names)
+        self.assertIn("market_review_limitup_event", table_names)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the model test to verify it fails**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_models -v
+```
+
+Expected:
+
+```text
+One failing assertion showing that `market_review_daily_metric` is missing from `Base.metadata.tables`
+```
+
+- [ ] **Step 3: Add the ORM models and config fields**
+
+```python
+# backend/app/models/market_review.py
+from datetime import datetime, date, time
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    JSON,
+    String,
+    Time,
+    UniqueConstraint,
+)
+
+from app.database import Base
+
+
+class MarketReviewDailyMetric(Base):
+    __tablename__ = "market_review_daily_metric"
+    __table_args__ = (UniqueConstraint("trade_date", name="uq_review_metric_trade_date"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False)
+    limit_up_count = Column(Integer, default=0, nullable=False)
+    limit_down_count = Column(Integer, default=0, nullable=False)
+    continuous_count = Column(Integer, default=0, nullable=False)
+    max_board_height = Column(Integer, default=0, nullable=False)
+    second_board_height = Column(Integer, default=0, nullable=False)
+    gem_board_height = Column(Integer, default=0, nullable=False)
+    first_to_second_rate = Column(Float, default=0, nullable=False)
+    continuous_promotion_rate = Column(Float, default=0, nullable=False)
+    seal_rate = Column(Float, default=0, nullable=False)
+    yesterday_limit_up_avg_change = Column(Float, default=0, nullable=False)
+    yesterday_continuous_avg_change = Column(Float, default=0, nullable=False)
+    market_turnover = Column(Float, default=0, nullable=False)
+    up_count_ex_st = Column(Integer, default=0, nullable=False)
+    down_count_ex_st = Column(Integer, default=0, nullable=False)
+    limit_up_amount = Column(Float, default=0, nullable=False)
+    broken_amount = Column(Float, default=0, nullable=False)
+    calc_version = Column(Integer, default=1, nullable=False)
+    source_status = Column(String(20), default="primary", nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False)
+
+
+class MarketReviewStockDaily(Base):
+    __tablename__ = "market_review_stock_daily"
+    __table_args__ = (UniqueConstraint("trade_date", "stock_code", name="uq_review_stock_daily"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False)
+    stock_code = Column(String(10), nullable=False)
+    stock_name = Column(String(50), nullable=False)
+    board_type = Column(String(20), default="main", nullable=False)
+    is_st = Column(Boolean, default=False, nullable=False)
+    yesterday_limit_up = Column(Boolean, default=False, nullable=False)
+    yesterday_continuous_days = Column(Integer, default=0, nullable=False)
+    today_touched_limit_up = Column(Boolean, default=False, nullable=False)
+    today_sealed_close = Column(Boolean, default=False, nullable=False)
+    today_opened_close = Column(Boolean, default=False, nullable=False)
+    today_broken = Column(Boolean, default=False, nullable=False)
+    today_continuous_days = Column(Integer, default=0, nullable=False)
+    first_limit_time = Column(Time)
+    final_seal_time = Column(Time)
+    open_count = Column(Integer, default=0, nullable=False)
+    close_price = Column(Float)
+    pre_close = Column(Float)
+    change_pct = Column(Float)
+    amount = Column(Float, default=0, nullable=False)
+    turnover_rate = Column(Float)
+    tradable_market_value = Column(Float)
+    limit_up_reason = Column(String(255))
+    data_quality_flag = Column(String(20), default="ok", nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False)
+
+
+class MarketReviewLimitUpEvent(Base):
+    __tablename__ = "market_review_limitup_event"
+    __table_args__ = (
+        UniqueConstraint("trade_date", "stock_code", "event_type", "event_seq", name="uq_review_limitup_event"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trade_date = Column(Date, nullable=False, index=True)
+    stock_code = Column(String(10), nullable=False, index=True)
+    event_type = Column(String(20), nullable=False, index=True)
+    event_time = Column(Time)
+    event_seq = Column(Integer, default=0, nullable=False)
+    source_name = Column(String(20), nullable=False)
+    payload_json = Column(JSON, default=dict, nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+```
+
+```python
+# backend/app/config.py
+# append inside the existing Settings class
+MARKET_REVIEW_ENABLED: bool = True
+MARKET_REVIEW_BUILD_HOUR: int = 15
+MARKET_REVIEW_BUILD_MINUTE: int = 5
+MARKET_REVIEW_REPAIR_HOUR: int = 20
+MARKET_REVIEW_REPAIR_MINUTE: int = 15
+MARKET_REVIEW_REPAIR_ENABLED: bool = True
+```
+
+```text
+# backend/requirements.txt
+akshare==1.16.88
+```
+
+- [ ] **Step 4: Run the model test again**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_models -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/app/models/market_review.py backend/app/models/__init__.py backend/app/config.py backend/requirements.txt backend/tests/test_market_review_models.py
+git commit -m "feat: add market review data model"
+```
+
+## Task 2: Implement Pure Daily Metric Aggregation
+
+**Files:**
+- Create: `backend/app/services/market_review_metrics_service.py`
+- Test: `backend/tests/test_market_review_metrics_service.py`
+
+- [ ] **Step 1: Write the failing aggregation tests**
+
+```python
+import unittest
+from datetime import date
+
+from app.services.market_review_metrics_service import MarketReviewMetricsService
+
+
+class MarketReviewMetricsServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.service = MarketReviewMetricsService()
+
+    def test_aggregate_daily_metrics_builds_review_totals(self):
+        rows = [
+            {
+                "stock_code": "600001",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 2,
+                "change_pct": 10.0,
+                "amount": 120000.0,
+            },
+            {
+                "stock_code": "300001",
+                "board_type": "gem",
+                "is_st": False,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 2,
+                "today_touched_limit_up": True,
+                "today_sealed_close": False,
+                "today_opened_close": True,
+                "today_broken": False,
+                "today_continuous_days": 3,
+                "change_pct": 4.5,
+                "amount": 80000.0,
+            },
+            {
+                "stock_code": "600002",
+                "board_type": "main",
+                "is_st": False,
+                "yesterday_limit_up": False,
+                "yesterday_continuous_days": 0,
+                "today_touched_limit_up": False,
+                "today_sealed_close": False,
+                "today_opened_close": False,
+                "today_broken": True,
+                "today_continuous_days": 0,
+                "change_pct": -3.2,
+                "amount": 10000.0,
+            },
+        ]
+
+        metric = self.service.aggregate_daily_metrics(
+            trade_date=date(2026, 4, 27),
+            stock_rows=rows,
+            limit_down_count=5,
+            market_turnover=12345.6,
+            up_count_ex_st=3200,
+            down_count_ex_st=1800,
+        )
+
+        self.assertEqual(metric["limit_up_count"], 2)
+        self.assertEqual(metric["continuous_count"], 2)
+        self.assertEqual(metric["max_board_height"], 3)
+        self.assertEqual(metric["second_board_height"], 2)
+        self.assertEqual(metric["gem_board_height"], 3)
+        self.assertAlmostEqual(metric["first_to_second_rate"], 100.0)
+        self.assertAlmostEqual(metric["continuous_promotion_rate"], 100.0)
+        self.assertAlmostEqual(metric["seal_rate"], 50.0)
+        self.assertAlmostEqual(metric["limit_up_amount"], 200000.0)
+        self.assertAlmostEqual(metric["broken_amount"], 80000.0)
+```
+
+- [ ] **Step 2: Run the aggregation tests to verify they fail**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_metrics_service -v
+```
+
+Expected:
+
+```text
+ModuleNotFoundError: No module named 'app.services.market_review_metrics_service'
+```
+
+- [ ] **Step 3: Implement the pure aggregation service**
+
+```python
+from collections import Counter
+from datetime import date
+from typing import Dict, List
+
+
+class MarketReviewMetricsService:
+    def aggregate_daily_metrics(
+        self,
+        trade_date: date,
+        stock_rows: List[Dict],
+        limit_down_count: int,
+        market_turnover: float,
+        up_count_ex_st: int,
+        down_count_ex_st: int,
+    ) -> Dict:
+        touched_rows = [row for row in stock_rows if row.get("today_touched_limit_up")]
+        sealed_rows = [row for row in touched_rows if row.get("today_sealed_close")]
+        opened_rows = [row for row in touched_rows if row.get("today_opened_close")]
+        ladder_days = sorted(
+            [int(row.get("today_continuous_days") or 0) for row in touched_rows if int(row.get("today_continuous_days") or 0) > 1],
+            reverse=True,
+        )
+
+        yesterday_first_board = [row for row in stock_rows if row.get("yesterday_limit_up") and int(row.get("yesterday_continuous_days") or 0) == 1]
+        yesterday_continuous = [row for row in stock_rows if int(row.get("yesterday_continuous_days") or 0) >= 2]
+
+        promoted_first_board = [row for row in yesterday_first_board if int(row.get("today_continuous_days") or 0) >= 2]
+        promoted_continuous = [
+            row for row in yesterday_continuous
+            if int(row.get("today_continuous_days") or 0) > int(row.get("yesterday_continuous_days") or 0)
+        ]
+
+        gem_days = [
+            int(row.get("today_continuous_days") or 0)
+            for row in touched_rows
+            if row.get("board_type") in {"gem", "star"}
+        ]
+
+        def avg(values: List[float]) -> float:
+            return round(sum(values) / len(values), 2) if values else 0.0
+
+        return {
+            "trade_date": trade_date,
+            "limit_up_count": len(touched_rows),
+            "limit_down_count": limit_down_count,
+            "continuous_count": len([row for row in touched_rows if int(row.get("today_continuous_days") or 0) >= 2]),
+            "max_board_height": ladder_days[0] if ladder_days else 0,
+            "second_board_height": ladder_days[1] if len(ladder_days) > 1 else 0,
+            "gem_board_height": max(gem_days) if gem_days else 0,
+            "first_to_second_rate": round(len(promoted_first_board) * 100 / len(yesterday_first_board), 2) if yesterday_first_board else 0.0,
+            "continuous_promotion_rate": round(len(promoted_continuous) * 100 / len(yesterday_continuous), 2) if yesterday_continuous else 0.0,
+            "seal_rate": round(len(sealed_rows) * 100 / len(touched_rows), 2) if touched_rows else 0.0,
+            "yesterday_limit_up_avg_change": avg([float(row.get("change_pct") or 0) for row in stock_rows if row.get("yesterday_limit_up")]),
+            "yesterday_continuous_avg_change": avg([float(row.get("change_pct") or 0) for row in stock_rows if int(row.get("yesterday_continuous_days") or 0) >= 2]),
+            "market_turnover": float(market_turnover or 0),
+            "up_count_ex_st": int(up_count_ex_st or 0),
+            "down_count_ex_st": int(down_count_ex_st or 0),
+            "limit_up_amount": round(sum(float(row.get("amount") or 0) for row in touched_rows), 2),
+            "broken_amount": round(sum(float(row.get("amount") or 0) for row in opened_rows), 2),
+        }
+```
+
+- [ ] **Step 4: Run the aggregation tests again**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_metrics_service -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/app/services/market_review_metrics_service.py backend/tests/test_market_review_metrics_service.py
+git commit -m "feat: add market review metrics aggregation"
+```
+
+## Task 3: Implement Source Normalization and Persistence Pipeline
+
+**Files:**
+- Create: `backend/app/services/market_review_source_service.py`
+- Create: `backend/app/services/market_review_pipeline_service.py`
+- Test: `backend/tests/test_market_review_pipeline_service.py`
+
+- [ ] **Step 1: Write the failing pipeline test**
+
+```python
+import unittest
+from datetime import date
+
+from app.services.market_review_pipeline_service import MarketReviewPipelineService
+
+
+class MarketReviewPipelineServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_for_date_upserts_fact_rows_and_metric(self):
+        service = MarketReviewPipelineService()
+        rows = [
+            {
+                "stock_code": "600001",
+                "stock_name": "测试一号",
+                "board_type": "main",
+                "today_touched_limit_up": True,
+                "today_sealed_close": True,
+                "today_opened_close": False,
+                "today_broken": False,
+                "today_continuous_days": 2,
+                "yesterday_limit_up": True,
+                "yesterday_continuous_days": 1,
+                "change_pct": 10.0,
+                "amount": 12345.0,
+                "open_count": 0,
+            }
+        ]
+
+        normalized = {
+            "stock_rows": rows,
+            "event_rows": [
+                {
+                    "stock_code": "600001",
+                    "event_type": "close_sealed",
+                    "event_seq": 1,
+                    "source_name": "EM",
+                    "payload_json": {"status": "sealed"},
+                }
+            ],
+            "limit_down_count": 3,
+            "market_turnover": 8888.8,
+            "up_count_ex_st": 3000,
+            "down_count_ex_st": 1700,
+            "source_status": "primary",
+        }
+
+        result = await service.build_payload_for_date(date(2026, 4, 27), normalized)
+        self.assertEqual(result["metric_row"]["limit_up_count"], 1)
+        self.assertEqual(result["stock_rows"][0]["stock_code"], "600001")
+        self.assertEqual(result["event_rows"][0]["event_type"], "close_sealed")
+```
+
+- [ ] **Step 2: Run the pipeline test to verify it fails**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_pipeline_service -v
+```
+
+Expected:
+
+```text
+ModuleNotFoundError: No module named 'app.services.market_review_pipeline_service'
+```
+
+- [ ] **Step 3: Implement the source service and orchestration pipeline**
+
+```python
+# backend/app/services/market_review_source_service.py
+from datetime import date
+from typing import Dict, List
+
+
+class MarketReviewSourceService:
+    async def collect_for_date(self, trade_date: date) -> Dict:
+        return {
+            "stock_rows": [],
+            "event_rows": [],
+            "limit_down_count": 0,
+            "market_turnover": 0.0,
+            "up_count_ex_st": 0,
+            "down_count_ex_st": 0,
+            "source_status": "primary",
+        }
+```
+
+```python
+# backend/app/services/market_review_pipeline_service.py
+from datetime import date
+from typing import Dict
+
+from app.database import async_session_maker
+from app.services.market_review_metrics_service import MarketReviewMetricsService
+from app.services.market_review_source_service import MarketReviewSourceService
+
+
+class MarketReviewPipelineService:
+    def __init__(self):
+        self.metrics = MarketReviewMetricsService()
+        self.sources = MarketReviewSourceService()
+
+    async def build_payload_for_date(self, trade_date: date, normalized: Dict | None = None) -> Dict:
+        normalized = normalized or await self.sources.collect_for_date(trade_date)
+        metric_row = self.metrics.aggregate_daily_metrics(
+            trade_date=trade_date,
+            stock_rows=normalized["stock_rows"],
+            limit_down_count=normalized["limit_down_count"],
+            market_turnover=normalized["market_turnover"],
+            up_count_ex_st=normalized["up_count_ex_st"],
+            down_count_ex_st=normalized["down_count_ex_st"],
+        )
+        metric_row["source_status"] = normalized.get("source_status", "primary")
+        return {
+            "metric_row": metric_row,
+            "stock_rows": normalized["stock_rows"],
+            "event_rows": normalized["event_rows"],
+        }
+
+    async def run_for_date(self, trade_date: date, calc_version: int = 1) -> Dict:
+        payload = await self.build_payload_for_date(trade_date)
+        payload["metric_row"]["calc_version"] = calc_version
+        async with async_session_maker() as db:
+            await self.persist_payload(db, payload)
+        return payload
+
+
+market_review_pipeline_service = MarketReviewPipelineService()
+```
+
+- [ ] **Step 4: Extend the pipeline to persist rows with upsert semantics**
+
+```python
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.market_review import (
+    MarketReviewDailyMetric,
+    MarketReviewLimitUpEvent,
+    MarketReviewStockDaily,
+)
+
+
+class MarketReviewPipelineService:
+    async def persist_payload(self, db: AsyncSession, payload: Dict) -> None:
+        trade_date = payload["metric_row"]["trade_date"]
+
+        metric_stmt = insert(MarketReviewDailyMetric).values(**payload["metric_row"])
+        metric_stmt = metric_stmt.on_conflict_do_update(
+            index_elements=["trade_date"],
+            set_=payload["metric_row"],
+        )
+        await db.execute(metric_stmt)
+
+        for row in payload["stock_rows"]:
+            stock_stmt = insert(MarketReviewStockDaily).values(**row)
+            stock_stmt = stock_stmt.on_conflict_do_update(
+                index_elements=["trade_date", "stock_code"],
+                set_=row,
+            )
+            await db.execute(stock_stmt)
+
+        for row in payload["event_rows"]:
+            event_stmt = insert(MarketReviewLimitUpEvent).values(**row)
+            event_stmt = event_stmt.on_conflict_do_update(
+                index_elements=["trade_date", "stock_code", "event_type", "event_seq"],
+                set_=row,
+            )
+            await db.execute(event_stmt)
+
+        await db.commit()
+```
+
+- [ ] **Step 5: Run the pipeline tests again**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_pipeline_service -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add backend/app/services/market_review_source_service.py backend/app/services/market_review_pipeline_service.py backend/tests/test_market_review_pipeline_service.py
+git commit -m "feat: add market review pipeline service"
+```
+
+## Task 4: Wire Scheduler Jobs and Historical Backfill
+
+**Files:**
+- Modify: `backend/app/data_collectors/scheduler.py`
+- Create: `backend/scripts/backfill_market_review.py`
+- Test: `backend/tests/test_market_review_scheduler.py`
+
+- [ ] **Step 1: Write the failing scheduler test**
+
+```python
+import unittest
+
+from app.data_collectors.scheduler import DataScheduler
+
+
+class MarketReviewSchedulerTests(unittest.TestCase):
+    def test_start_registers_review_jobs(self):
+        scheduler = DataScheduler()
+        scheduler.start()
+        try:
+            self.assertIsNotNone(scheduler.scheduler.get_job("market_review_build"))
+            self.assertIsNotNone(scheduler.scheduler.get_job("market_review_repair"))
+        finally:
+            scheduler.stop()
+```
+
+- [ ] **Step 2: Run the scheduler test to verify it fails**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_scheduler -v
+```
+
+Expected:
+
+```text
+FAIL: unexpectedly None
+```
+
+- [ ] **Step 3: Register review build and repair jobs**
+
+```python
+# backend/app/data_collectors/scheduler.py
+from app.services.market_review_pipeline_service import market_review_pipeline_service
+
+
+class DataScheduler:
+    def start(self):
+        if settings.MARKET_REVIEW_ENABLED:
+            self.scheduler.add_job(
+                self._build_market_review,
+                CronTrigger(hour=settings.MARKET_REVIEW_BUILD_HOUR, minute=settings.MARKET_REVIEW_BUILD_MINUTE),
+                id="market_review_build",
+                name="收盘后复盘构建",
+                max_instances=1,
+            )
+        if settings.MARKET_REVIEW_ENABLED and settings.MARKET_REVIEW_REPAIR_ENABLED:
+            self.scheduler.add_job(
+                self._repair_market_review,
+                CronTrigger(hour=settings.MARKET_REVIEW_REPAIR_HOUR, minute=settings.MARKET_REVIEW_REPAIR_MINUTE),
+                id="market_review_repair",
+                name="晚间复盘修正",
+                max_instances=1,
+            )
+
+    async def _build_market_review(self):
+        await market_review_pipeline_service.run_for_date(date.today(), calc_version=1)
+
+    async def _repair_market_review(self):
+        await market_review_pipeline_service.run_for_date(date.today(), calc_version=2)
+```
+
+```python
+# backend/scripts/backfill_market_review.py
+import asyncio
+from datetime import datetime, timedelta
+
+from app.services.market_review_pipeline_service import market_review_pipeline_service
+
+
+async def main():
+    start = datetime.strptime("2026-04-01", "%Y-%m-%d").date()
+    end = datetime.strptime("2026-04-30", "%Y-%m-%d").date()
+    current = start
+    while current <= end:
+        await market_review_pipeline_service.run_for_date(current, calc_version=9)
+        current += timedelta(days=1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 4: Run the scheduler test again**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_scheduler -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/app/data_collectors/scheduler.py backend/scripts/backfill_market_review.py backend/tests/test_market_review_scheduler.py
+git commit -m "feat: schedule market review jobs"
+```
+
+## Task 5: Expose Review APIs
+
+**Files:**
+- Create: `backend/app/schemas/market_review.py`
+- Create: `backend/app/api/v1/review.py`
+- Modify: `backend/app/api/v1/__init__.py`
+- Test: `backend/tests/test_market_review_api.py`
+
+- [ ] **Step 1: Write the failing API test**
+
+```python
+import unittest
+from datetime import date
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from app.api.v1.review import router
+from app.database import Base, get_db
+from app.models.market_review import MarketReviewDailyMetric
+
+
+class MarketReviewApiTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        self.session_maker = async_sessionmaker(self.engine, expire_on_commit=False)
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1/statistics/review")
+
+        async def override_get_db():
+            async with self.session_maker() as session:
+                yield session
+
+        app.dependency_overrides[get_db] = override_get_db
+        self.client = TestClient(app)
+
+    def test_daily_endpoint_returns_response_shape(self):
+        async def seed():
+            async with self.engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            async with self.session_maker() as session:
+                await session.execute(
+                    insert(MarketReviewDailyMetric).values(
+                        trade_date=date(2026, 4, 24),
+                        limit_up_count=59,
+                        limit_down_count=8,
+                        continuous_count=8,
+                        max_board_height=3,
+                        second_board_height=2,
+                        gem_board_height=1,
+                        first_to_second_rate=14.6,
+                        continuous_promotion_rate=22.2,
+                        seal_rate=74.7,
+                        yesterday_limit_up_avg_change=0.2,
+                        yesterday_continuous_avg_change=-2.41,
+                        market_turnover=26419,
+                        up_count_ex_st=1994,
+                        down_count_ex_st=3085,
+                        limit_up_amount=659,
+                        broken_amount=371,
+                    )
+                )
+                await session.commit()
+
+        import asyncio
+        asyncio.run(seed())
+        response = self.client.get("/api/v1/statistics/review/daily")
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertIn("data", body)
+        self.assertIn("series", body["data"])
+        self.assertEqual(body["data"]["rows"][0]["trade_date"], "2026-04-24")
+```
+
+- [ ] **Step 2: Run the API test to verify it fails**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_api -v
+```
+
+Expected:
+
+```text
+ModuleNotFoundError: No module named 'app.api.v1.review'
+```
+
+- [ ] **Step 3: Add schemas and router**
+
+```python
+# backend/app/schemas/market_review.py
+from datetime import date
+from pydantic import BaseModel, Field
+from typing import List, Dict
+
+
+class MarketReviewDailyPoint(BaseModel):
+    trade_date: date
+    limit_up_count: int
+    limit_down_count: int
+    continuous_count: int
+    max_board_height: int
+    second_board_height: int
+    gem_board_height: int
+    first_to_second_rate: float
+    continuous_promotion_rate: float
+    seal_rate: float
+    yesterday_limit_up_avg_change: float
+    yesterday_continuous_avg_change: float
+    market_turnover: float
+    up_count_ex_st: int
+    down_count_ex_st: int
+    limit_up_amount: float
+    broken_amount: float
+
+
+class MarketReviewDailyResponse(BaseModel):
+    data: Dict[str, List]
+```
+
+```python
+# backend/app/api/v1/review.py
+from fastapi import APIRouter, Query
+
+router = APIRouter()
+
+
+@router.get("/daily")
+async def get_review_daily(start_date: str | None = Query(None), end_date: str | None = Query(None)):
+    return {
+        "data": {
+            "series": [],
+            "rows": [],
+        }
+    }
+
+
+@router.get("/detail")
+async def get_review_detail(trade_date: str):
+    return {"trade_date": trade_date, "stocks": []}
+
+
+@router.get("/ladder")
+async def get_review_ladder(trade_date: str):
+    return {"trade_date": trade_date, "ladders": []}
+```
+
+```python
+# backend/app/api/v1/__init__.py
+from app.api.v1 import limit_up, statistics, market, config, websocket, review
+
+api_router = APIRouter()
+api_router.include_router(review.router, prefix="/statistics/review", tags=["复盘"])
+```
+
+- [ ] **Step 4: Replace stubbed router logic with DB-backed queries**
+
+```python
+from datetime import date
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.market_review import MarketReviewDailyMetric, MarketReviewStockDaily
+
+
+@router.get("/daily")
+async def get_review_daily(
+    start_date: str | None = Query(None),
+    end_date: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(MarketReviewDailyMetric)
+    if start_date:
+        query = query.where(MarketReviewDailyMetric.trade_date >= date.fromisoformat(start_date))
+    if end_date:
+        query = query.where(MarketReviewDailyMetric.trade_date <= date.fromisoformat(end_date))
+    result = await db.execute(query.order_by(MarketReviewDailyMetric.trade_date.asc()))
+    rows = result.scalars().all()
+    return {
+        "data": {
+            "series": [row.trade_date.isoformat() for row in rows],
+            "rows": [
+                {
+                    "trade_date": row.trade_date.isoformat(),
+                    "limit_up_count": row.limit_up_count,
+                    "limit_down_count": row.limit_down_count,
+                    "continuous_count": row.continuous_count,
+                    "max_board_height": row.max_board_height,
+                    "second_board_height": row.second_board_height,
+                    "gem_board_height": row.gem_board_height,
+                    "first_to_second_rate": row.first_to_second_rate,
+                    "continuous_promotion_rate": row.continuous_promotion_rate,
+                    "seal_rate": row.seal_rate,
+                    "yesterday_limit_up_avg_change": row.yesterday_limit_up_avg_change,
+                    "yesterday_continuous_avg_change": row.yesterday_continuous_avg_change,
+                    "market_turnover": row.market_turnover,
+                    "up_count_ex_st": row.up_count_ex_st,
+                    "down_count_ex_st": row.down_count_ex_st,
+                    "limit_up_amount": row.limit_up_amount,
+                    "broken_amount": row.broken_amount,
+                }
+                for row in rows
+            ],
+        }
+    }
+
+
+@router.get("/detail")
+async def get_review_detail(trade_date: str, db: AsyncSession = Depends(get_db)):
+    parsed_date = date.fromisoformat(trade_date)
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(MarketReviewStockDaily.trade_date == parsed_date)
+        .order_by(MarketReviewStockDaily.today_continuous_days.desc(), MarketReviewStockDaily.amount.desc())
+    )
+    stocks = result.scalars().all()
+    return {
+        "trade_date": trade_date,
+        "stocks": [
+            {
+                "stock_code": stock.stock_code,
+                "stock_name": stock.stock_name,
+                "today_continuous_days": stock.today_continuous_days,
+                "today_sealed_close": stock.today_sealed_close,
+                "today_opened_close": stock.today_opened_close,
+                "change_pct": stock.change_pct,
+                "amount": stock.amount,
+                "limit_up_reason": stock.limit_up_reason,
+            }
+            for stock in stocks
+        ],
+    }
+
+
+@router.get("/ladder")
+async def get_review_ladder(trade_date: str, db: AsyncSession = Depends(get_db)):
+    parsed_date = date.fromisoformat(trade_date)
+    result = await db.execute(
+        select(MarketReviewStockDaily)
+        .where(
+            MarketReviewStockDaily.trade_date == parsed_date,
+            MarketReviewStockDaily.today_touched_limit_up.is_(True),
+            MarketReviewStockDaily.today_continuous_days >= 2,
+        )
+        .order_by(MarketReviewStockDaily.today_continuous_days.desc(), MarketReviewStockDaily.amount.desc())
+    )
+    stocks = result.scalars().all()
+
+    ladders = {}
+    for stock in stocks:
+        ladders.setdefault(stock.today_continuous_days, [])
+        ladders[stock.today_continuous_days].append(
+            {
+                "stock_code": stock.stock_code,
+                "stock_name": stock.stock_name,
+                "today_continuous_days": stock.today_continuous_days,
+                "today_sealed_close": stock.today_sealed_close,
+                "today_opened_close": stock.today_opened_close,
+                "change_pct": stock.change_pct,
+                "amount": stock.amount,
+                "limit_up_reason": stock.limit_up_reason,
+            }
+        )
+
+    return {
+        "trade_date": trade_date,
+        "ladders": [
+            {"continuous_days": days, "count": len(items), "stocks": items}
+            for days, items in sorted(ladders.items(), reverse=True)
+        ],
+    }
+```
+
+- [ ] **Step 5: Run the API test again**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest tests.test_market_review_api -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add backend/app/schemas/market_review.py backend/app/api/v1/review.py backend/app/api/v1/__init__.py backend/tests/test_market_review_api.py
+git commit -m "feat: add market review endpoints"
+```
+
+## Task 6: Refactor the Frontend Statistics Page to Use Review APIs
+
+**Files:**
+- Create: `frontend/src/api/review.ts`
+- Modify: `frontend/src/api/index.ts`
+- Modify: `frontend/src/types/market.ts`
+- Modify: `frontend/src/views/Statistics.vue`
+
+- [ ] **Step 1: Add review API helpers and types**
+
+```ts
+// frontend/src/api/review.ts
+import axios from 'axios'
+import type { MarketReviewDailyResponse, MarketReviewDetailResponse, MarketReviewLadderResponse } from '@/types/market'
+
+const api = axios.create({
+  baseURL: '/api/v1',
+  timeout: 30000
+})
+
+export async function getMarketReviewDaily(params?: { start_date?: string; end_date?: string }): Promise<MarketReviewDailyResponse> {
+  const { data } = await api.get('/statistics/review/daily', { params })
+  return data
+}
+
+export async function getMarketReviewDetail(tradeDate: string): Promise<MarketReviewDetailResponse> {
+  const { data } = await api.get('/statistics/review/detail', { params: { trade_date: tradeDate } })
+  return data
+}
+
+export async function getMarketReviewLadder(tradeDate: string): Promise<MarketReviewLadderResponse> {
+  const { data } = await api.get('/statistics/review/ladder', { params: { trade_date: tradeDate } })
+  return data
+}
+```
+
+```ts
+// frontend/src/types/market.ts
+export interface MarketReviewDailyRow {
+  trade_date: string
+  limit_up_count: number
+  limit_down_count: number
+  continuous_count: number
+  max_board_height: number
+  second_board_height: number
+  gem_board_height: number
+  first_to_second_rate: number
+  continuous_promotion_rate: number
+  seal_rate: number
+  yesterday_limit_up_avg_change: number
+  yesterday_continuous_avg_change: number
+  market_turnover: number
+  up_count_ex_st: number
+  down_count_ex_st: number
+  limit_up_amount: number
+  broken_amount: number
+}
+
+export interface MarketReviewDailyResponse {
+  data: {
+    series: string[]
+    rows: MarketReviewDailyRow[]
+  }
+}
+
+export interface MarketReviewDetailStock {
+  stock_code: string
+  stock_name: string
+  today_continuous_days: number
+  today_sealed_close: boolean
+  today_opened_close: boolean
+  change_pct: number | null
+  amount: number
+  limit_up_reason?: string
+}
+
+export interface MarketReviewDetailResponse {
+  trade_date: string
+  stocks: MarketReviewDetailStock[]
+}
+
+export interface MarketReviewLadderLevel {
+  continuous_days: number
+  count: number
+  stocks: MarketReviewDetailStock[]
+}
+
+export interface MarketReviewLadderResponse {
+  trade_date: string
+  ladders: MarketReviewLadderLevel[]
+}
+```
+
+- [ ] **Step 2: Replace `Statistics.vue` data loading to use review endpoints**
+
+```ts
+import { getMarketReviewDaily, getMarketReviewDetail, getMarketReviewLadder } from '@/api'
+
+async function fetchData() {
+  const endDate = dayjs().format('YYYY-MM-DD')
+  const startDate = dayjs().subtract(parseInt(timeRange.value), 'day').format('YYYY-MM-DD')
+
+  const [daily, detail, ladder] = await Promise.all([
+    getMarketReviewDaily({ start_date: startDate, end_date: endDate }),
+    getMarketReviewDetail(endDate),
+    getMarketReviewLadder(endDate),
+  ])
+
+  updateHeightChart(daily.data.rows)
+  updatePromotionChart(daily.data.rows)
+  updateTrendChart(daily.data.rows)
+  updateTurnoverChart(daily.data.rows)
+  updateAmountChart(daily.data.rows)
+  updateDetailTables(detail, ladder)
+}
+```
+
+- [ ] **Step 3: Add chart groups that map exactly to the approved spec**
+
+```ts
+function updateHeightChart(rows: MarketReviewDailyRow[]) {
+  const dates = rows.map(row => row.trade_date)
+  heightChart?.setOption({
+    tooltip: { trigger: 'axis' },
+    legend: { data: ['连板高度', '次高高度', '创业板高度'] },
+    xAxis: { type: 'category', data: dates },
+    yAxis: { type: 'value' },
+    series: [
+      { name: '连板高度', type: 'line', smooth: true, data: rows.map(row => row.max_board_height) },
+      { name: '次高高度', type: 'line', smooth: true, data: rows.map(row => row.second_board_height) },
+      { name: '创业板高度', type: 'line', smooth: true, data: rows.map(row => row.gem_board_height) },
+    ],
+  })
+}
+```
+
+- [ ] **Step 4: Verify the page builds with the repo’s working frontend command**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\frontend
+npx vite build
+```
+
+Expected:
+
+```text
+Vite prints a successful build summary and emits frontend assets under `dist/`
+```
+
+```text
+Note: Do not use `npm run build` as the primary verification command for this task until the existing `vue-tsc` toolchain issue is fixed. Keep `npx vite build` as the required check in this implementation pass.
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add frontend/src/api/review.ts frontend/src/api/index.ts frontend/src/types/market.ts frontend/src/views/Statistics.vue
+git commit -m "feat: add market review dashboard"
+```
+
+## Task 7: Run End-to-End Verification and Stabilize
+
+**Files:**
+- Modify: `backend/app/services/market_review_pipeline_service.py`
+- Modify: `backend/app/api/v1/review.py`
+- Modify: `frontend/src/views/Statistics.vue`
+- Test: `backend/tests/test_market_review_models.py`
+- Test: `backend/tests/test_market_review_metrics_service.py`
+- Test: `backend/tests/test_market_review_pipeline_service.py`
+- Test: `backend/tests/test_market_review_scheduler.py`
+- Test: `backend/tests/test_market_review_api.py`
+
+- [ ] **Step 1: Run the backend market-review test suite**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m unittest `
+  tests.test_market_review_models `
+  tests.test_market_review_metrics_service `
+  tests.test_market_review_pipeline_service `
+  tests.test_market_review_scheduler `
+  tests.test_market_review_api -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 2: Run Python syntax verification on new backend files**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m py_compile `
+  app\models\market_review.py `
+  app\schemas\market_review.py `
+  app\services\market_review_metrics_service.py `
+  app\services\market_review_source_service.py `
+  app\services\market_review_pipeline_service.py `
+  app\api\v1\review.py `
+  scripts\backfill_market_review.py
+```
+
+Expected:
+
+```text
+<no output>
+```
+
+- [ ] **Step 3: Run the frontend build verification**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\frontend
+npx vite build
+```
+
+Expected:
+
+```text
+Vite prints a successful build summary and emits frontend assets under `dist/`
+```
+
+- [ ] **Step 4: Smoke-test the local review endpoints**
+
+Run:
+
+```powershell
+cd D:\code\stock-limit-up-system\backend
+.\venv\Scripts\python.exe -m uvicorn app.main:app --host 127.0.0.1 --port 8000
+```
+
+Then request:
+
+```powershell
+Invoke-WebRequest http://127.0.0.1:8000/api/v1/statistics/review/daily
+Invoke-WebRequest "http://127.0.0.1:8000/api/v1/statistics/review/detail?trade_date=2026-04-24"
+Invoke-WebRequest "http://127.0.0.1:8000/api/v1/statistics/review/ladder?trade_date=2026-04-24"
+```
+
+Expected:
+
+```text
+HTTP 200 for all three endpoints
+```
+
+- [ ] **Step 5: Commit the stabilization pass**
+
+```powershell
+git add backend/app/services/market_review_pipeline_service.py backend/app/api/v1/review.py frontend/src/views/Statistics.vue
+git commit -m "test: verify market review end to end"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Data model: Task 1
+  - Aggregation rules: Task 2
+  - Facts/events/metric persistence: Task 3
+  - Scheduled build, repair, and historical backfill: Task 4
+  - Review APIs: Task 5
+  - Frontend review charts: Task 6
+  - Verification and smoke tests: Task 7
+
+- Placeholder scan:
+  - No `TODO`, `TBD`, or “implement later” markers remain in the task steps
+  - Every task includes explicit files, commands, and expected outcomes
+
+- Type consistency:
+  - `today_touched_limit_up`, `today_sealed_close`, `today_opened_close`, `today_broken`, and `today_continuous_days` are used consistently across models, services, and tests
+  - Review API paths are consistently `/statistics/review/daily`, `/statistics/review/detail`, `/statistics/review/ladder`

--- a/docs/superpowers/specs/2026-04-25-market-review-design.md
+++ b/docs/superpowers/specs/2026-04-25-market-review-design.md
@@ -1,0 +1,505 @@
+# 收盘后日级复盘指标仓设计
+
+## 1. 背景
+
+当前项目已经具备以下基础能力：
+
+- 实时涨停池、炸板池聚合能力
+- 连板梯队和昨日连板今日表现接口
+- 基础统计接口和每日统计表
+- 前端基于 ECharts 的轻量统计页
+
+现阶段缺失的是一套面向“收盘后日级复盘”的稳定指标仓。当前页面多数数据仍依赖即时聚合或轻量统计，不适合承载以下目标：
+
+- 稳定输出复盘曲线
+- 支持历史区间查询
+- 支持回补和重算
+- 支持后续扩展到更完整的报表分析
+
+本设计只覆盖“收盘后日级复盘”，不覆盖盘中分时回放、竞价封单精确追踪和全量 tick 仓库建设。
+
+## 2. 目标
+
+构建一套可回补、可重算、口径一致的复盘指标仓，用于支撑以下报表能力：
+
+1. 连板高度
+2. 晋级率
+3. 昨日涨停平均涨幅
+4. 涨跌停趋势
+5. 沪深量能与涨跌家数
+6. 涨停股与炸板股成交金额
+
+目标要求如下：
+
+- 图表查询不依赖实时重算
+- 指标口径在接口、页面、历史回补之间一致
+- 支持按交易日幂等重跑
+- 数据源异常时具备降级和修正机制
+
+## 3. 非目标
+
+第一版明确不做以下内容：
+
+- 竞价一字涨停封单
+- 分钟级或 tick 级全市场行情仓
+- 盘中分时复盘回放
+- 多数据源逐笔仲裁引擎
+- 独立 BI 平台接入实施
+
+说明：
+
+- 后续如需接入 DataEase、Metabase、Superset 或 Datart，应复用本设计产出的聚合表，不改变数据底座。
+
+## 4. 外部参考与选型
+
+### 4.1 图表层
+
+- Apache ECharts
+  - 用途：继续承载项目内图表展示
+  - 参考仓库：https://github.com/apache/echarts
+  - 结论：适合折线图、柱状图、混合图和多序列趋势图
+
+### 4.2 数据回补与日级指标
+
+- AKShare
+  - 用途：历史日级数据回补、市场量能、宽度类指标补数
+  - 参考仓库：https://github.com/akfamily/akshare
+  - 结论：适合历史补数，不适合作为高实时唯一主链路
+
+- easyquotation
+  - 用途：轻量行情字段补充
+  - 参考仓库：https://github.com/shidenggui/easyquotation
+  - 结论：可作为辅源，不作为第一版复盘主口径来源
+
+- adata
+  - 用途：历史或行情字段补充
+  - 参考仓库：https://github.com/1nchaos/adata
+  - 结论：可作为补数辅源
+
+### 4.3 不作为第一版主体方案的项目
+
+- XtQuant
+  - 参考仓库：https://github.com/ai4trade/XtQuant
+  - 原因：适合更高实时性场景，对“收盘后日级复盘”属于过配
+
+- vn.py
+  - 参考仓库：https://github.com/vnpy/vnpy
+  - 原因：偏量化交易平台，不适合作为当前报表底座
+
+- QUANTAXIS
+  - 参考仓库：https://github.com/yutiansut/QUANTAXIS
+  - 原因：体系较重，接入成本高于当前目标收益
+
+## 5. 总体方案
+
+### 5.1 核心原则
+
+- 不建设“全量行情仓”，只建设“复盘指标仓”
+- 日级报表只认收盘后最终结果
+- 页面查询优先读取聚合表，不依赖外部接口实时计算
+- 历史回补与当日生成使用同一套口径和状态定义
+- 所有任务必须支持幂等执行
+
+### 5.2 分层结构
+
+系统分为四层：
+
+1. 采集层
+   - 现有实时涨停池/炸板池聚合
+   - 历史回补数据源（AKShare 为主）
+
+2. 事实层
+   - 按股票按交易日沉淀复盘事实
+   - 按事件沉淀涨停、炸板、回封、收盘状态
+
+3. 聚合层
+   - 将事实层计算为日级复盘指标
+
+4. 展示层
+   - 现有前端页面通过 API 查询聚合结果
+   - 后续可接 BI 平台
+
+## 6. 指标定义
+
+### 6.1 连板高度
+
+- `max_board_height`
+  - 定义：当日最高连板数
+- `second_board_height`
+  - 定义：当日次高连板数
+- `gem_board_height`
+  - 定义：创业板/科创板最高连板数
+
+口径规则：
+
+- 连板高度按“当日曾达成”的连板数计算
+- 收盘是否封住只作为附加状态，不改变高度值
+
+### 6.2 晋级率
+
+- `first_to_second_rate`
+  - 定义：昨日首板股中，今日晋级 2 板的比例
+- `continuous_promotion_rate`
+  - 定义：昨日 2 板及以上股票中，今日继续晋级的比例
+- `seal_rate`
+  - 定义：当日涨停股中，收盘封住的比例
+
+状态机定义：
+
+- `touch_limit`：当日曾涨停
+- `sealed_close`：收盘封住
+- `opened_close`：收盘未封住，但当日曾触板
+- `broken`：未触及目标晋级状态或最终断板
+
+说明：
+
+- 所有晋级率、昨日连板今日表现、报表统计必须复用同一状态机
+
+### 6.3 昨日涨停平均涨幅
+
+- `yesterday_limit_up_avg_change`
+  - 定义：昨日涨停股票在今日收盘的平均涨跌幅
+- `yesterday_continuous_avg_change`
+  - 定义：昨日连板股票在今日收盘的平均涨跌幅
+
+说明：
+
+- 第一版只统计收盘涨跌幅，不引入“含当日分时”口径
+
+### 6.4 涨跌停趋势
+
+- `continuous_count`
+  - 定义：当日连板股数量
+- `limit_up_count`
+  - 定义：当日涨停股数量
+- `limit_down_count`
+  - 定义：当日跌停股数量
+
+### 6.5 沪深量能与涨跌家数
+
+- `market_turnover`
+  - 定义：沪深两市成交额
+- `up_count_ex_st`
+  - 定义：不含 ST 的上涨家数
+- `down_count_ex_st`
+  - 定义：不含 ST 的下跌家数
+
+口径规则：
+
+- 第一版默认不含 ST
+- 如后续需要支持是否包含 ST，应作为维度扩展，不覆盖现有字段
+
+### 6.6 涨停股与炸板股成交金额
+
+- `limit_up_amount`
+  - 定义：当日涨停股成交总额
+- `broken_amount`
+  - 定义：当日炸板股成交总额
+
+口径规则：
+
+- 炸板股定义为“当日曾触板但收盘未封住”
+
+## 7. 数据模型设计
+
+### 7.1 `market_review_daily_metric`
+
+用途：
+
+- 一天一行，作为所有日级复盘图表的主查询表
+
+建议字段：
+
+- `id`
+- `trade_date`
+- `limit_up_count`
+- `limit_down_count`
+- `continuous_count`
+- `max_board_height`
+- `second_board_height`
+- `gem_board_height`
+- `first_to_second_rate`
+- `continuous_promotion_rate`
+- `seal_rate`
+- `yesterday_limit_up_avg_change`
+- `yesterday_continuous_avg_change`
+- `market_turnover`
+- `up_count_ex_st`
+- `down_count_ex_st`
+- `limit_up_amount`
+- `broken_amount`
+- `calc_version`
+- `source_status`
+- `created_at`
+- `updated_at`
+
+约束：
+
+- `trade_date` 唯一
+
+### 7.2 `market_review_stock_daily`
+
+用途：
+
+- 一天一股一行，保存复盘相关个股事实
+
+建议字段：
+
+- `id`
+- `trade_date`
+- `stock_code`
+- `stock_name`
+- `board_type`
+- `is_st`
+- `yesterday_limit_up`
+- `yesterday_continuous_days`
+- `today_touched_limit_up`
+- `today_sealed_close`
+- `today_opened_close`
+- `today_broken`
+- `today_continuous_days`
+- `first_limit_time`
+- `final_seal_time`
+- `open_count`
+- `close_price`
+- `pre_close`
+- `change_pct`
+- `amount`
+- `turnover_rate`
+- `tradable_market_value`
+- `limit_up_reason`
+- `data_quality_flag`
+- `created_at`
+- `updated_at`
+
+约束：
+
+- `(trade_date, stock_code)` 唯一
+
+### 7.3 `market_review_limitup_event`
+
+用途：
+
+- 保存个股关键事件轨迹，支持复盘解释和后续扩展
+
+建议字段：
+
+- `id`
+- `trade_date`
+- `stock_code`
+- `event_type`
+- `event_time`
+- `event_seq`
+- `source_name`
+- `payload_json`
+- `created_at`
+
+事件类型固定枚举：
+
+- `first_seal`
+- `open_board`
+- `re_seal`
+- `close_sealed`
+- `close_opened`
+- `close_broken`
+
+索引建议：
+
+- `(trade_date, stock_code)`
+- `(trade_date, event_type)`
+
+## 8. 数据流与调度
+
+### 8.1 收盘后首轮任务
+
+时间建议：`15:01 - 15:10`
+
+执行内容：
+
+- 拉取当日涨停池、炸板池、跌停池
+- 获取当日收盘价、昨收价、成交额、换手率等字段
+- 生成并写入 `market_review_stock_daily`
+- 生成并写入 `market_review_limitup_event`
+
+要求：
+
+- 以交易日为单位幂等执行
+- 使用唯一键加 upsert
+
+### 8.2 聚合任务
+
+时间建议：`15:10 - 15:20`
+
+执行内容：
+
+- 从 `market_review_stock_daily` 聚合生成 `market_review_daily_metric`
+- 不在该阶段直接依赖外部实时接口
+
+### 8.3 晚间修正任务
+
+时间建议：`20:00 - 21:00`
+
+执行内容：
+
+- 重跑当日事实层和聚合层
+- 修正收盘后源站字段延迟或补录
+
+要求：
+
+- 使用同一计算逻辑
+- 更新 `calc_version` 和 `updated_at`
+
+### 8.4 历史回补任务
+
+执行内容：
+
+- 按日期区间回补事实数据
+- 重算对应交易日聚合结果
+
+策略：
+
+- 先补 `market_review_stock_daily`
+- 再算 `market_review_daily_metric`
+- 按月或按周批量处理，避免一次性回补全历史
+
+## 9. 接口设计原则
+
+第一版建议新增以下接口，而不是直接在原始统计接口中堆逻辑：
+
+- `/statistics/review/daily`
+  - 查询日级复盘趋势数据
+- `/statistics/review/detail`
+  - 查询单日复盘明细
+- `/statistics/review/ladder`
+  - 查询单日连板高度和对应股票
+
+接口原则：
+
+- 图表趋势接口只查 `market_review_daily_metric`
+- 单日钻取接口查 `market_review_stock_daily`
+- 事件解释接口查 `market_review_limitup_event`
+
+## 10. 异常与数据质量策略
+
+### 10.1 收盘后源数据晚到
+
+问题：
+
+- 收盘后部分字段可能晚于首次任务可用
+
+策略：
+
+- 保留晚间修正任务
+- 使用 `calc_version` 标记重算版本
+
+### 10.2 多源字段冲突
+
+问题：
+
+- 不同源可能对成交额、状态、原因等字段存在差异
+
+策略：
+
+- 固定主源
+- 辅源仅补缺，不覆盖主源主口径
+- 原始差异保留在 `payload_json` 或诊断日志中
+
+### 10.3 口径漂移
+
+问题：
+
+- 页面、接口、历史回补若各自计算，易产生同名指标不同值
+
+策略：
+
+- 所有指标统一从聚合表读取
+- 所有聚合逻辑集中在单一服务层
+
+### 10.4 重跑脏数据
+
+问题：
+
+- 重跑任务可能重复写入或产生旧数据残留
+
+策略：
+
+- 使用唯一键 + upsert
+- 避免“先删后插”作为默认方案
+
+### 10.5 历史回补与当日口径不一致
+
+问题：
+
+- 历史回补源和盘中实时源可能字段不完全一致
+
+策略：
+
+- 报表只认“收盘后最终版本”
+- 历史回补使用同一状态机和聚合服务
+
+## 11. 性能与存储优化
+
+- 报表页只查 `market_review_daily_metric`
+- 钻取某日个股时才查 `market_review_stock_daily`
+- `market_review_limitup_event` 仅保存复盘相关股票，不保存全市场
+- 不为两三条日级曲线去建设全市场分钟仓或 tick 仓
+- 历史回补按月分批执行
+
+## 12. 实施阶段建议
+
+### 阶段 1：指标仓基础建设
+
+- 新建三张核心表
+- 实现收盘后事实写入和日聚合
+- 打通基础趋势接口
+
+### 阶段 2：报表页改造
+
+- 基于聚合表重构统计页
+- 新增连板高度、晋级率、昨日涨停平均涨幅等图表
+
+### 阶段 3：回补与修正
+
+- 增加历史回补任务
+- 增加晚间修正任务
+- 增加数据质量监控
+
+### 阶段 4：可选扩展
+
+- 接入 DataEase、Metabase 或其他 BI 平台
+- 增加更多市场宽度指标
+- 为第二阶段的盘中复盘预留快照能力
+
+## 13. 测试与验证策略
+
+### 13.1 单元测试
+
+- 状态机判断测试
+- 晋级率计算测试
+- 昨日涨停平均涨幅计算测试
+- 聚合服务幂等测试
+
+### 13.2 集成测试
+
+- 收盘事实写入测试
+- 日聚合任务测试
+- 历史回补任务测试
+
+### 13.3 数据验收
+
+- 随机抽取交易日，与人工复盘结果比对
+- 对比现有页面关键指标，定位历史口径差异
+- 对高波动交易日做专项校验
+
+## 14. 决策结论
+
+第一版采用以下路线：
+
+- 目标限定为“收盘后日级复盘”
+- 继续使用现有项目作为主承载系统
+- 建设复盘指标仓，而非全量行情仓
+- 图表继续使用 ECharts
+- 历史回补以 AKShare 为主
+- 第一版不纳入竞价封单和分时回放
+
+该方案在实现成本、口径稳定性、历史查询能力和后续扩展性之间取得平衡，适合作为当前项目的正式落地方案。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "sass": "^1.70.0",
         "typescript": "^5.3.3",
         "vite": "^5.0.11",
-        "vue-tsc": "^1.8.27"
+        "vue-tsc": "^3.2.7"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1158,31 +1158,32 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
-      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/source-map": "1.11.1"
+        "@volar/source-map": "2.4.28"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
-      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
-      "dependencies": {
-        "muggle-string": "^0.3.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
-      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "1.11.1",
-        "path-browserify": "^1.0.1"
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1237,28 +1238,19 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "node_modules/@vue/language-core": {
-      "version": "1.8.27",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.27.tgz",
-      "integrity": "sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.7.tgz",
+      "integrity": "sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "~1.11.1",
-        "@volar/source-map": "~1.11.1",
-        "@vue/compiler-dom": "^3.3.0",
-        "@vue/shared": "^3.3.0",
-        "computeds": "^0.0.1",
-        "minimatch": "^9.0.3",
-        "muggle-string": "^0.3.1",
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.1.2",
+        "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
-        "vue-template-compiler": "^2.7.14"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -1339,6 +1331,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/alien-signals": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
+      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-validator": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
@@ -1357,27 +1356,6 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1418,12 +1396,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/computeds": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
-      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
-      "dev": true
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1433,12 +1405,6 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1737,15 +1703,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/immutable": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
@@ -1835,26 +1792,12 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/muggle-string": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
-      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
-      "dev": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1889,7 +1832,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1897,11 +1841,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "optional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2044,18 +1988,6 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2146,6 +2078,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue": {
       "version": "3.5.28",
@@ -2255,31 +2194,21 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-      "dev": true,
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
     "node_modules/vue-tsc": {
-      "version": "1.8.27",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.27.tgz",
-      "integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.7.tgz",
+      "integrity": "sha512-zc1tL3HoQni1zGTGrwBVRQb7rGP5SWdu/m4rGB6JcnAC5MT5LFZIxF7Y+EJEnt4hGF23d60rXH7gRjHGb5KQQQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "~1.11.1",
-        "@vue/language-core": "1.8.27",
-        "semver": "^7.5.4"
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.2.7"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
       },
       "peerDependencies": {
-        "typescript": "*"
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/zrender": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^20.11.5",
         "@vitejs/plugin-vue": "^5.0.3",
         "sass": "^1.70.0",
-        "typescript": "^5.3.3",
+        "typescript": "5.3.3",
         "vite": "^5.0.11",
         "vue-tsc": "^1.8.27"
       }
@@ -2070,10 +2070,11 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview",
+    "test:review-range": "node tests/run-review-range-test.mjs",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,22 +9,22 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix"
   },
   "dependencies": {
-    "vue": "^3.4.15",
-    "vue-router": "^4.2.5",
-    "pinia": "^2.1.7",
-    "axios": "^1.6.5",
-    "element-plus": "^2.5.3",
     "@element-plus/icons-vue": "^2.3.1",
+    "axios": "^1.6.5",
+    "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
+    "element-plus": "^2.5.3",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.15",
     "vue-echarts": "^6.6.8",
-    "dayjs": "^1.11.10"
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
+    "@types/node": "^20.11.5",
     "@vitejs/plugin-vue": "^5.0.3",
+    "sass": "^1.70.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vue-tsc": "^1.8.27",
-    "@types/node": "^20.11.5",
-    "sass": "^1.70.0"
+    "vue-tsc": "^3.2.7"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.3",
-    "typescript": "^5.3.3",
+    "typescript": "5.3.3",
     "vite": "^5.0.11",
     "vue-tsc": "^1.8.27",
     "@types/node": "^20.11.5",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -99,7 +99,7 @@ import dayjs from 'dayjs'
 
 const route = useRoute()
 const alertStore = useAlertStore()
-const { connect, isConnected } = useWebSocket()
+const { connect } = useWebSocket()
 
 const isCollapsed = ref(false)
 const showAlertPanel = ref(false)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,6 +22,10 @@
               <el-icon><PieChart /></el-icon>
               <span>报表分析</span>
             </el-menu-item>
+            <el-menu-item index="/daily-analysis">
+              <el-icon><Calendar /></el-icon>
+              <span>每日分析</span>
+            </el-menu-item>
             <el-menu-item index="/continuous">
               <el-icon><TrendCharts /></el-icon>
               <span>连板梯队</span>
@@ -88,7 +92,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import {
   DataBoard, PieChart, Setting,
-  Fold, Expand, Bell, TrendCharts
+  Fold, Expand, Bell, TrendCharts, Calendar
 } from '@element-plus/icons-vue'
 import zhCn from 'element-plus/dist/locale/zh-cn.mjs'
 import AlertPanel from '@/components/alert/AlertPanel.vue'
@@ -99,7 +103,7 @@ import dayjs from 'dayjs'
 
 const route = useRoute()
 const alertStore = useAlertStore()
-const { connect, isConnected } = useWebSocket()
+const { connect } = useWebSocket()
 
 const isCollapsed = ref(false)
 const showAlertPanel = ref(false)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -95,10 +95,13 @@ import AlertPanel from '@/components/alert/AlertPanel.vue'
 import { useWebSocket } from '@/composables/useWebSocket'
 import { useSpeech } from '@/composables/useSpeech'
 import { useAlertStore } from '@/stores/alert'
+import { useConfigStore } from '@/stores/config'
+import { getConfig, toggleAlert as toggleAlertConfig } from '@/api/config'
 import dayjs from 'dayjs'
 
 const route = useRoute()
 const alertStore = useAlertStore()
+const configStore = useConfigStore()
 const { connect } = useWebSocket()
 
 const isCollapsed = ref(false)
@@ -138,19 +141,40 @@ const marketStatusText = computed(() => {
 })
 
 // 切换播报
-const toggleAlert = (enabled: boolean) => {
+const loadAlertConfig = async () => {
+  try {
+    const config = await getConfig()
+    configStore.setConfig(config)
+    alertEnabled.value = config.alert_limit_up_enabled
+    alertStore.setEnabled(config.alert_limit_up_enabled)
+    alertStore.setSoundEnabled(config.alert_sound_enabled)
+    alertStore.setDesktopEnabled(config.alert_desktop_enabled)
+  } catch (e) {
+    console.error('Load alert config error:', e)
+  }
+}
+
+const toggleAlert = async (enabled: boolean) => {
   alertStore.setEnabled(enabled)
+  configStore.setConfig({ alert_limit_up_enabled: enabled })
   const { announceEnabled, announceDisabled } = useSpeech()
   if (enabled) {
     announceEnabled()
   } else {
     announceDisabled()
   }
+
+  try {
+    await toggleAlertConfig('limit_up', enabled)
+  } catch (e) {
+    console.error('Toggle alert config error:', e)
+  }
 }
 
 // 更新时间
 let timeInterval: number
 onMounted(() => {
+  loadAlertConfig()
   connect()
   timeInterval = window.setInterval(() => {
     currentTime.value = dayjs().format('HH:mm:ss')

--- a/frontend/src/api/daily-analysis.ts
+++ b/frontend/src/api/daily-analysis.ts
@@ -1,0 +1,41 @@
+import axios from 'axios'
+import type {
+  DailyAnalysisBackfillResponse,
+  DailyAnalysisColumn,
+  DailyAnalysisMonthResponse,
+  DailyAnalysisRow
+} from '@/types/daily-analysis'
+
+const api = axios.create({
+  baseURL: '/api/v1',
+  timeout: 30000
+})
+
+export async function getDailyAnalysisMonth(month: string): Promise<DailyAnalysisMonthResponse> {
+  const { data } = await api.get('/statistics/daily-analysis', {
+    params: { month }
+  })
+  return data
+}
+
+export async function rebuildDailyAnalysis(tradeDate: string): Promise<DailyAnalysisRow> {
+  const { data } = await api.post(`/statistics/daily-analysis/${tradeDate}/rebuild`)
+  return data
+}
+
+export async function updateDailyAnalysisOverrides(
+  tradeDate: string,
+  overrides: Partial<Record<DailyAnalysisColumn, string | null>>
+): Promise<DailyAnalysisRow> {
+  const { data } = await api.patch(`/statistics/daily-analysis/${tradeDate}/overrides`, {
+    overrides
+  })
+  return data
+}
+
+export async function backfillDailyAnalysis(month: string): Promise<DailyAnalysisBackfillResponse> {
+  const { data } = await api.post('/statistics/daily-analysis/backfill', {
+    month
+  })
+  return data
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './limit-up'
 export * from './statistics'
+export * from './review'
 export * from './market'
 export * from './config'

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './limit-up'
 export * from './statistics'
+export * from './daily-analysis'
 export * from './market'
 export * from './config'

--- a/frontend/src/api/review.ts
+++ b/frontend/src/api/review.ts
@@ -1,0 +1,33 @@
+import axios from 'axios'
+import type {
+  MarketReviewDailyResponse,
+  MarketReviewDetailResponse,
+  MarketReviewLadderResponse
+} from '@/types/market'
+
+const api = axios.create({
+  baseURL: '/api/v1',
+  timeout: 30000
+})
+
+export async function getMarketReviewDaily(params?: {
+  start_date?: string
+  end_date?: string
+}): Promise<MarketReviewDailyResponse> {
+  const { data } = await api.get('/statistics/review/daily', { params })
+  return data
+}
+
+export async function getMarketReviewDetail(tradeDate: string): Promise<MarketReviewDetailResponse> {
+  const { data } = await api.get('/statistics/review/detail', {
+    params: { trade_date: tradeDate }
+  })
+  return data
+}
+
+export async function getMarketReviewLadder(tradeDate: string): Promise<MarketReviewLadderResponse> {
+  const { data } = await api.get('/statistics/review/ladder', {
+    params: { trade_date: tradeDate }
+  })
+  return data
+}

--- a/frontend/src/api/review.ts
+++ b/frontend/src/api/review.ts
@@ -13,6 +13,7 @@ const api = axios.create({
 export async function getMarketReviewDaily(params?: {
   start_date?: string
   end_date?: string
+  days?: number
 }): Promise<MarketReviewDailyResponse> {
   const { data } = await api.get('/statistics/review/daily', { params })
   return data

--- a/frontend/src/api/review.ts
+++ b/frontend/src/api/review.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import type {
   MarketReviewDailyResponse,
   MarketReviewDetailResponse,
+  MarketReviewIntradayResponse,
   MarketReviewLadderResponse
 } from '@/types/market'
 
@@ -29,6 +30,13 @@ export async function getMarketReviewDetail(tradeDate: string): Promise<MarketRe
 export async function getMarketReviewLadder(tradeDate: string): Promise<MarketReviewLadderResponse> {
   const { data } = await api.get('/statistics/review/ladder', {
     params: { trade_date: tradeDate }
+  })
+  return data
+}
+
+export async function getMarketReviewIntraday(tradeDate?: string): Promise<MarketReviewIntradayResponse> {
+  const { data } = await api.get('/statistics/review/intraday', {
+    params: tradeDate ? { trade_date: tradeDate } : undefined
   })
   return data
 }

--- a/frontend/src/api/statistics.ts
+++ b/frontend/src/api/statistics.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { DailyStats, SectorStats, ContinuousLadder, SectorStatsResponse, ContinuousLadderResponse, YesterdayContinuousResponse } from '@/types/market'
+import type { DailyStats, SectorStatsResponse, ContinuousLadderResponse, YesterdayContinuousResponse } from '@/types/market'
 
 const api = axios.create({
   baseURL: '/api/v1',

--- a/frontend/src/composables/useSpeech.ts
+++ b/frontend/src/composables/useSpeech.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useConfigStore } from '@/stores/config'
 
 // 语音播报配置 - 从config store获取设置

--- a/frontend/src/composables/useSpeech.ts
+++ b/frontend/src/composables/useSpeech.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { useConfigStore } from '@/stores/config'
+import { useAlertStore } from '@/stores/alert'
 
 // 语音播报配置 - 从config store获取设置
 const speechRate = ref(1.2) // 语速
@@ -9,7 +10,8 @@ const speechVolume = ref(0.8) // 音量
 function getSpeechEnabled(): boolean {
   try {
     const configStore = useConfigStore()
-    return configStore.config.alert_limit_up_enabled
+    const alertStore = useAlertStore()
+    return alertStore.enabled && configStore.config.alert_limit_up_enabled
   } catch {
     return false
   }

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onUnmounted } from 'vue'
 import { useAlertStore } from '@/stores/alert'
 import { useLimitUpStore } from '@/stores/limit-up'
 import { useSpeech } from '@/composables/useSpeech'
@@ -98,14 +98,14 @@ export function useWebSocket() {
         break
 
       case 'limit_up_snapshot':
-        limitUpStore.setSnapshot(
+        limitUpStore.setRealtimeSnapshot(
           message.data.trade_date || '',
           message.data.items || []
         )
         break
 
       case 'limit_up_delta':
-        limitUpStore.applyDelta(
+        limitUpStore.applyRealtimeDelta(
           message.data.upsert || [],
           message.data.remove || [],
           message.data.trade_date || ''

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -95,6 +95,10 @@ export function useWebSocket() {
           content: `首次涨停 ${message.data.time}${message.data.reason ? ` - ${message.data.reason}` : ''}`,
           time: message.timestamp
         })
+        if (message.data.stock_name) {
+          const { announceStock } = useSpeech()
+          announceStock(message.data.stock_name, message.data.reason)
+        }
         break
 
       case 'limit_up_snapshot':

--- a/frontend/src/composables/useWebSocket.ts
+++ b/frontend/src/composables/useWebSocket.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onUnmounted } from 'vue'
 import { useAlertStore } from '@/stores/alert'
 import { useLimitUpStore } from '@/stores/limit-up'
 import { useSpeech } from '@/composables/useSpeech'

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -43,7 +43,7 @@ const router = createRouter({
   ]
 })
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
   document.title = `${to.meta.title || '股票涨停分析系统'}`
   next()
 })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -28,6 +28,12 @@ const router = createRouter({
       meta: { title: '统计分析' }
     },
     {
+      path: '/daily-analysis',
+      name: 'DailyAnalysis',
+      component: () => import('@/views/DailyAnalysis.vue'),
+      meta: { title: '每日分析' }
+    },
+    {
       path: '/continuous',
       name: 'ContinuousBoard',
       component: () => import('@/views/ContinuousBoard.vue'),
@@ -43,7 +49,7 @@ const router = createRouter({
   ]
 })
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
   document.title = `${to.meta.title || '股票涨停分析系统'}`
   next()
 })

--- a/frontend/src/stores/alert.ts
+++ b/frontend/src/stores/alert.ts
@@ -80,7 +80,7 @@ export const useAlertStore = defineStore('alert', () => {
   }
 
   // 播放声音
-  function playSound(type: string) {
+  function playSound(_type: string) {
     // 使用Web Audio API或Audio元素播放提示音
     try {
       const audio = new Audio('/sounds/alert.mp3')

--- a/frontend/src/stores/limit-up.ts
+++ b/frontend/src/stores/limit-up.ts
@@ -7,6 +7,7 @@ export const useLimitUpStore = defineStore('limitUp', () => {
   const realtimeList = ref<LimitUpRealtime[]>([])
   const tradeDate = ref('')
   const lastSyncAt = ref('')
+  const acceptRealtimeUpdates = ref(true)
   
   // 加载状态
   const loading = ref(false)
@@ -76,6 +77,15 @@ export const useLimitUpStore = defineStore('limitUp', () => {
     setList(list, snapshotTradeDate)
   }
 
+  function setAcceptRealtimeUpdates(enabled: boolean) {
+    acceptRealtimeUpdates.value = enabled
+  }
+
+  function setRealtimeSnapshot(snapshotTradeDate: string, list: LimitUpRealtime[]) {
+    if (!acceptRealtimeUpdates.value) return
+    setSnapshot(snapshotTradeDate, list)
+  }
+
   // 更新单条记录
   function updateItem(code: string, data: Partial<LimitUpRealtime>) {
     const index = realtimeList.value.findIndex(item => item.stock_code === code)
@@ -128,6 +138,15 @@ export const useLimitUpStore = defineStore('limitUp', () => {
     lastSyncAt.value = new Date().toISOString()
   }
 
+  function applyRealtimeDelta(
+    upsert: LimitUpRealtime[],
+    remove: string[] = [],
+    deltaTradeDate = ''
+  ) {
+    if (!acceptRealtimeUpdates.value) return
+    applyDelta(upsert, remove, deltaTradeDate)
+  }
+
   // 设置筛选条件
   function setFilters(newFilters: Partial<typeof filters.value>) {
     Object.assign(filters.value, newFilters)
@@ -137,16 +156,20 @@ export const useLimitUpStore = defineStore('limitUp', () => {
     realtimeList,
     tradeDate,
     lastSyncAt,
+    acceptRealtimeUpdates,
     loading,
     filters,
     filteredList,
     stats,
     setList,
     setSnapshot,
+    setAcceptRealtimeUpdates,
+    setRealtimeSnapshot,
     updateItem,
     addItem,
     removeItems,
     applyDelta,
+    applyRealtimeDelta,
     setFilters
   }
 })

--- a/frontend/src/types/daily-analysis.ts
+++ b/frontend/src/types/daily-analysis.ts
@@ -1,0 +1,52 @@
+export const DAILY_ANALYSIS_COLUMNS = [
+  '连板唯一性',
+  '反包+趋势+弹钢琴',
+  '炸板反包',
+  '辨识度',
+  '二波',
+  '20cm',
+  '一字套利',
+  '板块',
+  '负反馈'
+] as const
+
+export type DailyAnalysisColumn = typeof DAILY_ANALYSIS_COLUMNS[number]
+
+export interface DailyAnalysisItem {
+  stock_code?: string
+  stock_name?: string
+  label: string
+  tags: string[]
+  reason?: string
+  time?: string | null
+  score?: number
+  content?: string
+}
+
+export interface DailyAnalysisCell {
+  items: DailyAnalysisItem[]
+  content: string
+  is_manual?: boolean
+}
+
+export interface DailyAnalysisRow {
+  trade_date: string
+  month: string
+  status: string
+  calc_version: number
+  generated_at?: string | null
+  updated_at?: string | null
+  auto_result: Record<DailyAnalysisColumn, DailyAnalysisCell>
+  manual_overrides: Partial<Record<DailyAnalysisColumn, string>>
+  columns: Record<DailyAnalysisColumn, DailyAnalysisCell>
+}
+
+export interface DailyAnalysisMonthResponse {
+  month: string
+  data: DailyAnalysisRow[]
+}
+
+export interface DailyAnalysisBackfillResponse {
+  built_count: number
+  trade_dates: string[]
+}

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -138,6 +138,12 @@ export interface MarketReviewDailyResponse {
     series: string[]
     rows: MarketReviewDailyRow[]
   }
+  requested_start_date?: string | null
+  requested_end_date?: string | null
+  start_date?: string | null
+  end_date?: string | null
+  latest_trade_date?: string | null
+  is_fallback?: boolean
 }
 
 export interface MarketReviewDetailStock {

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -111,3 +111,60 @@ export interface YesterdayContinuousResponse {
   is_fallback: boolean
   data: YesterdayContinuousLadder[]
 }
+
+// 市场复盘相关类型
+export interface MarketReviewDailyRow {
+  trade_date: string
+  limit_up_count: number
+  limit_down_count: number
+  continuous_count: number
+  max_board_height: number
+  second_board_height: number
+  gem_board_height: number
+  first_to_second_rate: number
+  continuous_promotion_rate: number
+  seal_rate: number
+  yesterday_limit_up_avg_change: number
+  yesterday_continuous_avg_change: number
+  market_turnover: number
+  up_count_ex_st: number
+  down_count_ex_st: number
+  limit_up_amount: number
+  broken_amount: number
+}
+
+export interface MarketReviewDailyResponse {
+  data: {
+    series: string[]
+    rows: MarketReviewDailyRow[]
+  }
+}
+
+export interface MarketReviewDetailStock {
+  stock_code: string
+  stock_name: string
+  today_continuous_days: number
+  today_sealed_close: boolean
+  today_opened_close: boolean
+  change_pct: number | null
+  amount: number
+  limit_up_reason: string | null
+}
+
+export interface MarketReviewDetailResponse {
+  trade_date: string
+  is_fallback: boolean
+  stocks: MarketReviewDetailStock[]
+}
+
+export interface MarketReviewLadderLevel {
+  continuous_days: number
+  count: number
+  stocks: MarketReviewDetailStock[]
+}
+
+export interface MarketReviewLadderResponse {
+  trade_date: string
+  is_fallback: boolean
+  ladders: MarketReviewLadderLevel[]
+}

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -121,6 +121,9 @@ export interface MarketReviewDailyRow {
   max_board_height: number
   second_board_height: number
   gem_board_height: number
+  max_board_label?: string | null
+  second_board_label?: string | null
+  gem_board_label?: string | null
   first_to_second_rate: number
   continuous_promotion_rate: number
   seal_rate: number

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -169,6 +169,11 @@ export interface MarketReviewDetailResponse {
 export interface MarketReviewLadderLevel {
   continuous_days: number
   count: number
+  cohort_count: number
+  cohort_sealed_count: number
+  cohort_opened_count: number
+  cohort_seal_rate: number
+  cohort_avg_change: number | null
   stocks: MarketReviewDetailStock[]
 }
 

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -177,3 +177,10 @@ export interface MarketReviewLadderResponse {
   is_fallback: boolean
   ladders: MarketReviewLadderLevel[]
 }
+
+export interface MarketReviewIntradayResponse extends MarketReviewDailyResponse {
+  is_intraday: true
+  snapshot_time: string
+  detail: MarketReviewDetailResponse
+  ladder: MarketReviewLadderResponse
+}

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -185,6 +185,7 @@ export interface MarketReviewLadderResponse {
 
 export interface MarketReviewIntradayResponse extends MarketReviewDailyResponse {
   is_intraday: true
+  is_live: boolean
   snapshot_time: string
   detail: MarketReviewDetailResponse
   ladder: MarketReviewLadderResponse

--- a/frontend/src/utils/reviewRange.ts
+++ b/frontend/src/utils/reviewRange.ts
@@ -9,9 +9,17 @@ export interface ReviewRange {
   query: ReviewRangeQuery
 }
 
+const QUICK_RANGE_TRADING_DAYS: Record<string, number> = {
+  '7': 7,
+  '30': 30,
+  '3m': 60
+}
+
 export function buildReviewRange(timeRange: string, currentDate: string): ReviewRange {
   const parsedDays = Number.parseInt(timeRange, 10)
-  const days = Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : 30
+  const days = QUICK_RANGE_TRADING_DAYS[timeRange] ?? (
+    Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : 30
+  )
 
   return {
     startDate: currentDate,

--- a/frontend/src/utils/reviewRange.ts
+++ b/frontend/src/utils/reviewRange.ts
@@ -1,0 +1,24 @@
+export interface ReviewRangeQuery {
+  days: number
+  end_date: string
+}
+
+export interface ReviewRange {
+  startDate: string
+  endDate: string
+  query: ReviewRangeQuery
+}
+
+export function buildReviewRange(timeRange: string, currentDate: string): ReviewRange {
+  const parsedDays = Number.parseInt(timeRange, 10)
+  const days = Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : 30
+
+  return {
+    startDate: currentDate,
+    endDate: currentDate,
+    query: {
+      days,
+      end_date: currentDate
+    }
+  }
+}

--- a/frontend/src/views/DailyAnalysis.vue
+++ b/frontend/src/views/DailyAnalysis.vue
@@ -1,0 +1,483 @@
+<template>
+  <div class="daily-analysis">
+    <div class="toolbar card">
+      <div class="toolbar-title">
+        <h3>每日分析</h3>
+        <span>近10日涨停/触板池自动识别，支持人工修正</span>
+      </div>
+      <div class="toolbar-actions">
+        <el-date-picker
+          v-model="selectedMonth"
+          type="month"
+          value-format="YYYY-MM"
+          format="YYYY-MM"
+          :clearable="false"
+          :editable="false"
+        />
+        <el-button :icon="Refresh" @click="fetchData" :loading="loading">刷新</el-button>
+        <el-button type="primary" :icon="Files" @click="backfillMonth" :loading="backfilling">
+          回填本月
+        </el-button>
+      </div>
+    </div>
+
+    <div class="table-wrap card">
+      <el-table
+        :data="rows"
+        v-loading="loading"
+        border
+        height="calc(100vh - 178px)"
+        :header-cell-style="{ background: '#fafafa', fontWeight: 600 }"
+      >
+        <el-table-column prop="trade_date" label="时间" width="116" fixed>
+          <template #default="{ row }">
+            <div class="date-cell">
+              <strong>{{ row.trade_date }}</strong>
+              <span>v{{ row.calc_version }}</span>
+            </div>
+          </template>
+        </el-table-column>
+
+        <el-table-column
+          v-for="column in analysisColumns"
+          :key="column"
+          :label="column"
+          min-width="230"
+        >
+          <template #default="{ row }">
+            <div class="analysis-cell" :class="{ manual: cell(row, column).is_manual }">
+              <div class="cell-tools">
+                <el-tag v-if="cell(row, column).is_manual" size="small" type="warning">人工</el-tag>
+                <el-tooltip content="编辑单元格" placement="top">
+                  <el-button :icon="Edit" link size="small" @click.stop="openEdit(row, column)" />
+                </el-tooltip>
+                <el-tooltip v-if="cell(row, column).is_manual" content="恢复自动结果" placement="top">
+                  <el-button :icon="RefreshLeft" link size="small" @click.stop="restoreOverride(row, column)" />
+                </el-tooltip>
+              </div>
+
+              <div v-if="cell(row, column).is_manual" class="manual-content">
+                {{ cell(row, column).content || '-' }}
+              </div>
+
+              <template v-else-if="cell(row, column).items.length">
+                <div class="item-list">
+                  <button
+                    v-for="item in cell(row, column).items"
+                    :key="`${item.stock_code || item.label}-${item.tags.join('-')}`"
+                    class="signal-item"
+                    :class="{ clickable: Boolean(item.stock_code) }"
+                    type="button"
+                    @click.stop="goStock(item.stock_code)"
+                  >
+                    <span class="item-label">{{ item.label }}</span>
+                    <span v-if="item.time" class="item-time">{{ item.time }}</span>
+                    <span class="tag-list">
+                      <el-tag
+                        v-for="tag in item.tags"
+                        :key="tag"
+                        :type="tagType(tag)"
+                        size="small"
+                      >
+                        {{ tag }}
+                      </el-tag>
+                    </span>
+                  </button>
+                </div>
+              </template>
+
+              <span v-else class="empty-cell">-</span>
+            </div>
+          </template>
+        </el-table-column>
+
+        <el-table-column label="操作" width="106" fixed="right" align="center">
+          <template #default="{ row }">
+            <el-button :icon="Refresh" link type="primary" @click.stop="rebuildRow(row)">
+              重算
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-empty v-if="!loading && rows.length === 0" description="本月暂无分析数据，可先回填本月" />
+    </div>
+
+    <el-dialog v-model="editVisible" :title="editTitle" width="560px">
+      <div class="edit-dialog">
+        <div class="auto-preview">
+          <span>自动结果</span>
+          <p>{{ editingAutoContent || '-' }}</p>
+        </div>
+        <el-input
+          v-model="editText"
+          type="textarea"
+          :rows="5"
+          maxlength="500"
+          show-word-limit
+          placeholder="填写人工修正内容"
+        />
+      </div>
+      <template #footer>
+        <el-button @click="editVisible = false">取消</el-button>
+        <el-button v-if="canRestoreEditingCell" @click="restoreEditingOverride" :loading="saving">
+          恢复自动
+        </el-button>
+        <el-button type="primary" @click="saveOverride" :loading="saving">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Edit, Files, Refresh, RefreshLeft } from '@element-plus/icons-vue'
+import dayjs from 'dayjs'
+import {
+  backfillDailyAnalysis,
+  getDailyAnalysisMonth,
+  rebuildDailyAnalysis,
+  updateDailyAnalysisOverrides
+} from '@/api/daily-analysis'
+import {
+  DAILY_ANALYSIS_COLUMNS,
+  type DailyAnalysisCell,
+  type DailyAnalysisColumn,
+  type DailyAnalysisRow
+} from '@/types/daily-analysis'
+
+const router = useRouter()
+const analysisColumns = DAILY_ANALYSIS_COLUMNS
+const selectedMonth = ref(dayjs().format('YYYY-MM'))
+const rows = ref<DailyAnalysisRow[]>([])
+const loading = ref(false)
+const backfilling = ref(false)
+const saving = ref(false)
+
+const editVisible = ref(false)
+const editText = ref('')
+const editingRow = ref<DailyAnalysisRow | null>(null)
+const editingColumn = ref<DailyAnalysisColumn | null>(null)
+
+const emptyCell: DailyAnalysisCell = {
+  items: [],
+  content: ''
+}
+
+const editTitle = computed(() => {
+  if (!editingRow.value || !editingColumn.value) return '编辑'
+  return `${editingRow.value.trade_date} ${editingColumn.value}`
+})
+
+const editingAutoContent = computed(() => {
+  if (!editingRow.value || !editingColumn.value) return ''
+  return editingRow.value.auto_result[editingColumn.value]?.content || ''
+})
+
+const canRestoreEditingCell = computed(() => {
+  if (!editingRow.value || !editingColumn.value) return false
+  return Boolean(editingRow.value.columns[editingColumn.value]?.is_manual)
+})
+
+watch(selectedMonth, () => {
+  fetchData()
+})
+
+onMounted(() => {
+  fetchData()
+})
+
+async function fetchData() {
+  loading.value = true
+  try {
+    const response = await getDailyAnalysisMonth(selectedMonth.value)
+    rows.value = response.data
+  } catch (error) {
+    console.error('获取每日分析失败:', error)
+    ElMessage.error('获取每日分析失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function backfillMonth() {
+  try {
+    await ElMessageBox.confirm(`将按现有历史数据生成 ${selectedMonth.value} 月表，是否继续？`, '回填本月', {
+      type: 'warning'
+    })
+    backfilling.value = true
+    const response = await backfillDailyAnalysis(selectedMonth.value)
+    ElMessage.success(`已生成 ${response.built_count} 个交易日`)
+    await fetchData()
+  } catch (error) {
+    if (error !== 'cancel') {
+      console.error('回填每日分析失败:', error)
+      ElMessage.error('回填失败')
+    }
+  } finally {
+    backfilling.value = false
+  }
+}
+
+async function rebuildRow(row: DailyAnalysisRow) {
+  try {
+    await ElMessageBox.confirm(`重算 ${row.trade_date} 的自动分析，人工修正会保留。`, '重算单日', {
+      type: 'warning'
+    })
+    const updated = await rebuildDailyAnalysis(row.trade_date)
+    replaceRow(updated)
+    ElMessage.success('重算完成')
+  } catch (error) {
+    if (error !== 'cancel') {
+      console.error('重算每日分析失败:', error)
+      ElMessage.error('重算失败')
+    }
+  }
+}
+
+function openEdit(row: DailyAnalysisRow, column: DailyAnalysisColumn) {
+  editingRow.value = row
+  editingColumn.value = column
+  editText.value = row.manual_overrides[column] ?? row.columns[column]?.content ?? ''
+  editVisible.value = true
+}
+
+async function saveOverride() {
+  if (!editingRow.value || !editingColumn.value) return
+
+  saving.value = true
+  try {
+    const updated = await updateDailyAnalysisOverrides(editingRow.value.trade_date, {
+      [editingColumn.value]: editText.value
+    })
+    replaceRow(updated)
+    editVisible.value = false
+    ElMessage.success('已保存人工修正')
+  } catch (error) {
+    console.error('保存人工修正失败:', error)
+    ElMessage.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function restoreEditingOverride() {
+  if (!editingRow.value || !editingColumn.value) return
+  await restoreOverride(editingRow.value, editingColumn.value)
+  editVisible.value = false
+}
+
+async function restoreOverride(row: DailyAnalysisRow, column: DailyAnalysisColumn) {
+  saving.value = true
+  try {
+    const updated = await updateDailyAnalysisOverrides(row.trade_date, {
+      [column]: null
+    })
+    replaceRow(updated)
+    ElMessage.success('已恢复自动结果')
+  } catch (error) {
+    console.error('恢复自动结果失败:', error)
+    ElMessage.error('恢复失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+function replaceRow(updated: DailyAnalysisRow) {
+  const index = rows.value.findIndex(row => row.trade_date === updated.trade_date)
+  if (index >= 0) {
+    rows.value.splice(index, 1, updated)
+  } else {
+    rows.value.unshift(updated)
+  }
+}
+
+function cell(row: DailyAnalysisRow, column: DailyAnalysisColumn): DailyAnalysisCell {
+  return row.columns[column] || emptyCell
+}
+
+function goStock(stockCode?: string) {
+  if (!stockCode) return
+  router.push(`/stock/${stockCode}`)
+}
+
+function tagType(tag: string): 'success' | 'warning' | 'danger' | 'info' {
+  if (tag.includes('负') || tag.includes('炸')) return 'danger'
+  if (tag.includes('人工') || tag.includes('长上影')) return 'warning'
+  if (tag.includes('趋势') || tag.includes('二波')) return 'success'
+  return 'info'
+}
+</script>
+
+<style lang="scss" scoped>
+.daily-analysis {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+
+  .toolbar-title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    h3 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+      color: #1f1f1f;
+    }
+
+    span {
+      font-size: 12px;
+      color: #8c8c8c;
+    }
+  }
+
+  .toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+}
+
+.table-wrap {
+  position: relative;
+  padding: 0;
+  overflow: hidden;
+}
+
+.date-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  strong {
+    font-size: 13px;
+    color: #262626;
+  }
+
+  span {
+    font-size: 12px;
+    color: #8c8c8c;
+  }
+}
+
+.analysis-cell {
+  min-height: 76px;
+  position: relative;
+  padding: 4px 0 0;
+
+  &.manual {
+    background: #fffbe6;
+    margin: -8px;
+    padding: 8px;
+    min-height: 92px;
+  }
+}
+
+.cell-tools {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  min-height: 24px;
+}
+
+.item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.signal-item {
+  width: 100%;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  background: #fafafa;
+  padding: 6px;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  flex-wrap: wrap;
+  text-align: left;
+  color: #262626;
+
+  &.clickable {
+    cursor: pointer;
+
+    &:hover {
+      border-color: #91caff;
+      background: #e6f4ff;
+    }
+  }
+}
+
+.item-label {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 22px;
+}
+
+.item-time {
+  font-size: 12px;
+  color: #8c8c8c;
+  line-height: 22px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.manual-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #594214;
+}
+
+.empty-cell {
+  display: block;
+  color: #bfbfbf;
+  font-size: 13px;
+  padding-top: 10px;
+}
+
+.edit-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.auto-preview {
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  padding: 10px;
+
+  span {
+    color: #8c8c8c;
+    font-size: 12px;
+  }
+
+  p {
+    margin: 6px 0 0;
+    color: #262626;
+    font-size: 13px;
+    line-height: 1.5;
+    word-break: break-word;
+  }
+}
+</style>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -3,6 +3,17 @@
     <!-- 筛选区 -->
     <div class="filter-bar card">
       <el-form inline>
+        <el-form-item label="交易日期">
+          <el-date-picker
+            v-model="selectedDate"
+            type="date"
+            value-format="YYYY-MM-DD"
+            format="YYYY-MM-DD"
+            :clearable="false"
+            style="width: 150px"
+            @change="handleDateChange"
+          />
+        </el-form-item>
         <el-form-item label="连板天数">
           <el-select v-model="filters.minContinuousDays" placeholder="全部" clearable style="width: 120px">
             <el-option label="2板以上" :value="2" />
@@ -27,6 +38,11 @@
           <el-button @click="resetFilters">重置</el-button>
           <el-button type="warning" @click="refreshData" :loading="refreshing">刷新数据</el-button>
           <el-button @click="exportData">导出</el-button>
+        </el-form-item>
+        <el-form-item v-if="displayTradeDate">
+          <el-tag :type="isFallbackDate ? 'warning' : 'info'" size="small">
+            数据日期 {{ displayTradeDate }}
+          </el-tag>
         </el-form-item>
         <el-form-item label="排序">
           <el-button-group size="small">
@@ -116,8 +132,9 @@
 <script setup lang="ts">
 import { computed, ref, reactive, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { ElMessage, ElMessageBox } from 'element-plus'
-import { getRealtimeLimitUp, refreshLimitUpData } from '@/api/limit-up'
+import { ElMessage } from 'element-plus'
+import dayjs from 'dayjs'
+import { getRealtimeLimitUp } from '@/api/limit-up'
 import { useLimitUpStore } from '@/stores/limit-up'
 import type { LimitUpRealtime } from '@/types/limit-up'
 
@@ -127,6 +144,7 @@ const limitUpStore = useLimitUpStore()
 const loading = ref(false)
 const refreshing = ref(false)
 const isFetching = ref(false)
+const selectedDate = ref(dayjs().format('YYYY-MM-DD'))
 const sortBy = ref<'time' | 'reseal_time' | 'seal_amount' | 'continuous_days'>('time')
 const RESYNC_INTERVAL = 90000
 let refreshTimer: number | null = null
@@ -141,6 +159,12 @@ interface FetchOptions {
   showLoading?: boolean
   silent?: boolean
 }
+
+const displayTradeDate = computed(() => limitUpStore.tradeDate)
+const isSelectedToday = computed(() => selectedDate.value === dayjs().format('YYYY-MM-DD'))
+const isFallbackDate = computed(
+  () => Boolean(displayTradeDate.value && displayTradeDate.value !== selectedDate.value)
+)
 
 const reasonCategories = computed(() => {
   const cats = new Set<string>()
@@ -202,8 +226,13 @@ async function fetchData(options: FetchOptions = {}) {
   }
 
   try {
-    const response = await getRealtimeLimitUp()
+    const response = await getRealtimeLimitUp({
+      trade_date: selectedDate.value
+    })
     limitUpStore.setSnapshot(response.trade_date, response.data || [])
+    if (response.is_fallback && !silent) {
+      ElMessage.warning(`未找到 ${selectedDate.value} 数据，已显示 ${response.trade_date}`)
+    }
   } catch (e) {
     console.error('Fetch error:', e)
     if (!silent) {
@@ -221,6 +250,15 @@ function applyFilters() {
   // 列表已由计算属性自动响应筛选条件变化
 }
 
+function updateRealtimeMode() {
+  limitUpStore.setAcceptRealtimeUpdates(isSelectedToday.value)
+}
+
+function handleDateChange() {
+  updateRealtimeMode()
+  fetchData({ showLoading: true })
+}
+
 function setSortBy(type: 'time' | 'reseal_time' | 'seal_amount' | 'continuous_days') {
   sortBy.value = type
 }
@@ -233,24 +271,12 @@ function resetFilters() {
 
 async function refreshData() {
   try {
-    await ElMessageBox.confirm(
-      '将从开盘啦/同花顺重新获取涨停原因和状态，是否继续？',
-      '刷新数据',
-      { type: 'warning' }
-    )
-
     refreshing.value = true
-    await refreshLimitUpData()
-    ElMessage.success('刷新请求已提交，请稍后刷新页面查看')
-
-    setTimeout(() => {
-      fetchData({ showLoading: false, silent: true })
-    }, 3000)
+    await fetchData({ showLoading: false, silent: false })
+    ElMessage.success('数据已刷新')
   } catch (e: any) {
-    if (e !== 'cancel') {
-      console.error('Refresh error:', e)
-      ElMessage.error('刷新失败')
-    }
+    console.error('Refresh error:', e)
+    ElMessage.error('刷新失败')
   } finally {
     refreshing.value = false
   }
@@ -300,14 +326,17 @@ function exportData() {
 }
 
 onMounted(() => {
+  updateRealtimeMode()
   fetchData({ showLoading: limitUpStore.realtimeList.length === 0 })
   refreshTimer = window.setInterval(() => {
     if (document.visibilityState !== 'visible') return
+    if (!isSelectedToday.value) return
     fetchData({ showLoading: false, silent: true })
   }, RESYNC_INTERVAL)
 })
 
 onUnmounted(() => {
+  limitUpStore.setAcceptRealtimeUpdates(true)
   if (refreshTimer) {
     clearInterval(refreshTimer)
     refreshTimer = null

--- a/frontend/src/views/HeatMap.vue
+++ b/frontend/src/views/HeatMap.vue
@@ -17,6 +17,7 @@
 import { ref, watch, onMounted, onUnmounted } from 'vue'
 import * as echarts from 'echarts'
 import { getSectorStats, getContinuousLadder } from '@/api/statistics'
+import type { ContinuousLadder, SectorStats } from '@/types/market'
 
 const viewType = ref('sector')
 const heatmapRef = ref<HTMLElement>()
@@ -25,15 +26,15 @@ let chart: echarts.ECharts | null = null
 
 async function fetchData() {
   if (viewType.value === 'sector') {
-    const data = await getSectorStats()
-    updateSectorHeatmap(data)
+    const response = await getSectorStats()
+    updateSectorHeatmap(response.data)
   } else {
-    const data = await getContinuousLadder()
-    updateContinuousHeatmap(data)
+    const response = await getContinuousLadder()
+    updateContinuousHeatmap(response.data)
   }
 }
 
-function updateSectorHeatmap(data: any[]) {
+function updateSectorHeatmap(data: SectorStats[]) {
   if (!chart) return
   
   // 转换为treemap数据格式
@@ -84,7 +85,7 @@ function updateSectorHeatmap(data: any[]) {
   })
 }
 
-function updateContinuousHeatmap(data: any[]) {
+function updateContinuousHeatmap(data: ContinuousLadder[]) {
   if (!chart) return
   
   // 转换为treemap数据格式
@@ -94,7 +95,7 @@ function updateContinuousHeatmap(data: any[]) {
     itemStyle: {
       color: getColorByDays(ladder.continuous_days)
     },
-    children: ladder.stocks?.map((stock: any) => ({
+    children: ladder.stocks?.map(stock => ({
       name: stock.stock_name,
       value: 1
     })) || []

--- a/frontend/src/views/HeatMap.vue
+++ b/frontend/src/views/HeatMap.vue
@@ -25,11 +25,11 @@ let chart: echarts.ECharts | null = null
 
 async function fetchData() {
   if (viewType.value === 'sector') {
-    const data = await getSectorStats()
-    updateSectorHeatmap(data)
+    const response = await getSectorStats()
+    updateSectorHeatmap(response.data)
   } else {
-    const data = await getContinuousLadder()
-    updateContinuousHeatmap(data)
+    const response = await getContinuousLadder()
+    updateContinuousHeatmap(response.data)
   }
 }
 

--- a/frontend/src/views/LimitUpList.vue
+++ b/frontend/src/views/LimitUpList.vue
@@ -3,6 +3,17 @@
     <!-- 筛选区 -->
     <div class="filter-bar card">
       <el-form inline>
+        <el-form-item label="交易日期">
+          <el-date-picker
+            v-model="selectedDate"
+            type="date"
+            value-format="YYYY-MM-DD"
+            format="YYYY-MM-DD"
+            :clearable="false"
+            style="width: 150px"
+            @change="handleDateChange"
+          />
+        </el-form-item>
         <el-form-item label="连板天数">
           <el-select v-model="filters.minContinuousDays" placeholder="全部" clearable style="width: 120px">
             <el-option label="2板以上" :value="2" />
@@ -27,6 +38,11 @@
           <el-button @click="resetFilters">重置</el-button>
           <el-button type="warning" @click="refreshData" :loading="refreshing">刷新数据</el-button>
           <el-button @click="exportData">导出</el-button>
+        </el-form-item>
+        <el-form-item v-if="displayTradeDate">
+          <el-tag :type="isFallbackDate ? 'warning' : 'info'" size="small">
+            数据日期 {{ displayTradeDate }}
+          </el-tag>
         </el-form-item>
       </el-form>
     </div>
@@ -109,8 +125,9 @@
 <script setup lang="ts">
 import { computed, ref, reactive, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { ElMessage, ElMessageBox } from 'element-plus'
-import { getRealtimeLimitUp, refreshLimitUpData } from '@/api/limit-up'
+import { ElMessage } from 'element-plus'
+import dayjs from 'dayjs'
+import { getRealtimeLimitUp } from '@/api/limit-up'
 import { useLimitUpStore } from '@/stores/limit-up'
 import type { LimitUpRealtime } from '@/types/limit-up'
 
@@ -120,6 +137,7 @@ const limitUpStore = useLimitUpStore()
 const loading = ref(false)
 const refreshing = ref(false)
 const isFetching = ref(false)
+const selectedDate = ref(dayjs().format('YYYY-MM-DD'))
 const tableSort = ref<{ prop: string; order: 'ascending' | 'descending' | null }>({
   prop: '',
   order: null
@@ -137,6 +155,12 @@ interface FetchOptions {
   showLoading?: boolean
   silent?: boolean
 }
+
+const displayTradeDate = computed(() => limitUpStore.tradeDate)
+const isSelectedToday = computed(() => selectedDate.value === dayjs().format('YYYY-MM-DD'))
+const isFallbackDate = computed(
+  () => Boolean(displayTradeDate.value && displayTradeDate.value !== selectedDate.value)
+)
 
 const reasonCategories = computed(() => {
   const cats = new Set<string>()
@@ -195,8 +219,13 @@ async function fetchData(options: FetchOptions = {}) {
   }
 
   try {
-    const response = await getRealtimeLimitUp()
+    const response = await getRealtimeLimitUp({
+      trade_date: selectedDate.value
+    })
     limitUpStore.setSnapshot(response.trade_date, response.data || [])
+    if (response.is_fallback && !silent) {
+      ElMessage.warning(`未找到 ${selectedDate.value} 数据，已显示 ${response.trade_date}`)
+    }
   } catch (e) {
     console.error('Fetch error:', e)
     if (!silent) {
@@ -214,6 +243,15 @@ function applyFilters() {
   // 列表已由计算属性自动响应筛选条件变化
 }
 
+function updateRealtimeMode() {
+  limitUpStore.setAcceptRealtimeUpdates(isSelectedToday.value)
+}
+
+function handleDateChange() {
+  updateRealtimeMode()
+  fetchData({ showLoading: true })
+}
+
 function resetFilters() {
   filters.minContinuousDays = undefined
   filters.reasonCategory = ''
@@ -222,24 +260,12 @@ function resetFilters() {
 
 async function refreshData() {
   try {
-    await ElMessageBox.confirm(
-      '将从开盘啦/同花顺重新获取涨停原因和状态，是否继续？',
-      '刷新数据',
-      { type: 'warning' }
-    )
-
     refreshing.value = true
-    await refreshLimitUpData()
-    ElMessage.success('刷新请求已提交，请稍后刷新页面查看')
-
-    setTimeout(() => {
-      fetchData({ showLoading: false, silent: true })
-    }, 3000)
+    await fetchData({ showLoading: false, silent: false })
+    ElMessage.success('数据已刷新')
   } catch (e: any) {
-    if (e !== 'cancel') {
-      console.error('Refresh error:', e)
-      ElMessage.error('刷新失败')
-    }
+    console.error('Refresh error:', e)
+    ElMessage.error('刷新失败')
   } finally {
     refreshing.value = false
   }
@@ -296,14 +322,17 @@ function exportData() {
 }
 
 onMounted(() => {
+  updateRealtimeMode()
   fetchData({ showLoading: limitUpStore.realtimeList.length === 0 })
   refreshTimer = window.setInterval(() => {
     if (document.visibilityState !== 'visible') return
+    if (!isSelectedToday.value) return
     fetchData({ showLoading: false, silent: true })
   }, RESYNC_INTERVAL)
 })
 
 onUnmounted(() => {
+  limitUpStore.setAcceptRealtimeUpdates(true)
   if (refreshTimer) {
     clearInterval(refreshTimer)
     refreshTimer = null

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -10,7 +10,7 @@
         <el-radio-group v-model="timeRange" size="small">
           <el-radio-button label="7">近7天</el-radio-button>
           <el-radio-button label="30">近30天</el-radio-button>
-          <el-radio-button label="90">近3月</el-radio-button>
+          <el-radio-button label="3m">近3月</el-radio-button>
         </el-radio-group>
       </div>
 

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -1,50 +1,220 @@
 <template>
-  <div class="statistics">
+  <div class="statistics" v-loading="loading">
+    <div class="card summary-card">
+      <div class="summary-main">
+        <div class="summary-copy">
+          <h3>市场复盘统计</h3>
+          <p>用复盘指标跟踪连板高度、晋级率、情绪与量能变化。</p>
+        </div>
+
+        <el-radio-group v-model="timeRange" size="small">
+          <el-radio-button label="7">近7天</el-radio-button>
+          <el-radio-button label="30">近30天</el-radio-button>
+          <el-radio-button label="90">近3月</el-radio-button>
+        </el-radio-group>
+      </div>
+
+      <div class="summary-meta">
+        <span>区间 {{ activeStartDate }} 至 {{ activeEndDate }}</span>
+        <span>明细日期 {{ resolvedTradeDate }}</span>
+        <el-tag v-if="hasFallback" type="warning" size="small">
+          已回退到最近可用数据
+        </el-tag>
+      </div>
+    </div>
+
     <el-row :gutter="16">
-      <!-- 趋势图 -->
-      <el-col :span="16">
-        <div class="card">
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
           <div class="card-header">
-            <h3>涨停数量趋势</h3>
-            <el-radio-group v-model="timeRange" size="small">
-              <el-radio-button label="7">近7天</el-radio-button>
-              <el-radio-button label="30">近30天</el-radio-button>
-              <el-radio-button label="90">近3月</el-radio-button>
-            </el-radio-group>
+            <div>
+              <h3>连板高度</h3>
+              <p>龙头高度、二板家数与创业板涨停梯度。</p>
+            </div>
           </div>
-          <div ref="trendChartRef" class="chart-container"></div>
+          <div ref="boardHeightChartRef" class="chart-container"></div>
         </div>
       </el-col>
-
-      <!-- 连板分布 -->
-      <el-col :span="8">
-        <div class="card">
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
           <div class="card-header">
-            <h3>连板分布</h3>
+            <div>
+              <h3>晋级率</h3>
+              <p>首板进二板、连板晋级与封板率联动观察。</p>
+            </div>
           </div>
-          <div ref="pieChartRef" class="chart-container"></div>
+          <div ref="promotionRateChartRef" class="chart-container"></div>
         </div>
       </el-col>
     </el-row>
 
     <el-row :gutter="16">
-      <!-- 炸板率趋势 -->
-      <el-col :span="12">
-        <div class="card">
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
           <div class="card-header">
-            <h3>炸板率趋势</h3>
+            <div>
+              <h3>昨日涨停平均涨幅</h3>
+              <p>昨日涨停与昨日连板次日反馈对比。</p>
+            </div>
           </div>
-          <div ref="breakChartRef" class="chart-container"></div>
+          <div ref="yesterdayChangeChartRef" class="chart-container"></div>
+        </div>
+      </el-col>
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
+          <div class="card-header">
+            <div>
+              <h3>涨跌停趋势</h3>
+              <p>连板家数、涨停与跌停数量的情绪脉冲。</p>
+            </div>
+          </div>
+          <div ref="limitTrendChartRef" class="chart-container"></div>
+        </div>
+      </el-col>
+    </el-row>
+
+    <el-row :gutter="16">
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
+          <div class="card-header">
+            <div>
+              <h3>沪深量能与涨跌家数</h3>
+              <p>量能与非ST涨跌家数的市场广度对照。</p>
+            </div>
+          </div>
+          <div ref="breadthChartRef" class="chart-container"></div>
+        </div>
+      </el-col>
+      <el-col :xs="24" :lg="12">
+        <div class="card chart-card">
+          <div class="card-header">
+            <div>
+              <h3>涨停/炸板成交额</h3>
+              <p>封板成交额与炸板成交额的资金去向。</p>
+            </div>
+          </div>
+          <div ref="amountChartRef" class="chart-container"></div>
+        </div>
+      </el-col>
+    </el-row>
+
+    <el-row :gutter="16">
+      <el-col :xs="24" :lg="9">
+        <div class="card detail-card">
+          <div class="card-header">
+            <div>
+              <h3>连板梯队</h3>
+              <p>当前复盘日的高标结构与封板状态。</p>
+            </div>
+          </div>
+
+          <div v-if="ladderLevels.length" class="ladder-list">
+            <div v-for="ladder in ladderLevels" :key="ladder.continuous_days" class="ladder-group">
+              <div class="ladder-header">
+                <span class="days-badge" :class="'days-' + Math.min(ladder.continuous_days, 10)">
+                  {{ ladder.continuous_days }}连板
+                </span>
+                <span class="count">{{ ladder.count }}只</span>
+                <span class="ladder-stat">封板 {{ getSealedCount(ladder) }}</span>
+                <span class="ladder-stat ladder-stat-warning">炸板 {{ getOpenedCount(ladder) }}</span>
+              </div>
+
+              <div class="stock-chip-list">
+                <button
+                  v-for="stock in ladder.stocks"
+                  :key="stock.stock_code"
+                  type="button"
+                  class="stock-chip"
+                  @click="goToDetail(stock.stock_code)"
+                >
+                  <span class="code">{{ stock.stock_code }}</span>
+                  <span class="name">{{ stock.stock_name }}</span>
+                  <el-tag :type="getStockStatusType(stock)" size="small">
+                    {{ getStockStatusLabel(stock) }}
+                  </el-tag>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <el-empty v-else description="暂无连板梯队数据" />
         </div>
       </el-col>
 
-      <!-- 板块统计 -->
-      <el-col :span="12">
-        <div class="card">
+      <el-col :xs="24" :lg="15">
+        <div class="card detail-card">
           <div class="card-header">
-            <h3>板块涨停排名</h3>
+            <div>
+              <h3>复盘明细</h3>
+              <p>按连板高度与成交额排序的个股复盘列表。</p>
+            </div>
           </div>
-          <div ref="sectorChartRef" class="chart-container"></div>
+
+          <div class="detail-summary">
+            <div class="summary-item">
+              <span class="label">复盘个股</span>
+              <strong>{{ detailStocks.length }}</strong>
+            </div>
+            <div class="summary-item">
+              <span class="label">封板收盘</span>
+              <strong>{{ sealedCloseCount }}</strong>
+            </div>
+            <div class="summary-item">
+              <span class="label">炸板收盘</span>
+              <strong>{{ openedCloseCount }}</strong>
+            </div>
+            <div class="summary-item">
+              <span class="label">主导题材</span>
+              <strong>{{ strongestReason }}</strong>
+            </div>
+          </div>
+
+          <el-table
+            :data="detailStocks"
+            size="small"
+            stripe
+            max-height="420"
+            empty-text="暂无复盘明细"
+            @row-click="handleRowClick"
+          >
+            <el-table-column prop="stock_name" label="个股" min-width="180">
+              <template #default="{ row }">
+                <div class="stock-cell">
+                  <span class="name">{{ row.stock_name }}</span>
+                  <span class="code">{{ row.stock_code }}</span>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column prop="today_continuous_days" label="连板" width="80" align="center">
+              <template #default="{ row }">
+                <span>{{ row.today_continuous_days }}板</span>
+              </template>
+            </el-table-column>
+            <el-table-column label="收盘状态" width="100" align="center">
+              <template #default="{ row }">
+                <el-tag :type="getStockStatusType(row)" size="small">
+                  {{ getStockStatusLabel(row) }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="change_pct" label="涨跌幅" width="100" align="right">
+              <template #default="{ row }">
+                <span :class="getChangeClass(row.change_pct)">
+                  {{ formatPercent(row.change_pct) }}
+                </span>
+              </template>
+            </el-table-column>
+            <el-table-column prop="amount" label="成交额" width="120" align="right">
+              <template #default="{ row }">
+                {{ formatAmount(row.amount) }}
+              </template>
+            </el-table-column>
+            <el-table-column prop="limit_up_reason" label="涨停原因" min-width="160" show-overflow-tooltip>
+              <template #default="{ row }">
+                {{ row.limit_up_reason || '-' }}
+              </template>
+            </el-table-column>
+          </el-table>
         </div>
       </el-col>
     </el-row>
@@ -52,185 +222,783 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
 import * as echarts from 'echarts'
-import { getDailyStats, getSectorStats } from '@/api/statistics'
 import dayjs from 'dayjs'
+import { getMarketReviewDaily, getMarketReviewDetail, getMarketReviewLadder } from '@/api'
+import type {
+  MarketReviewDailyRow,
+  MarketReviewDetailResponse,
+  MarketReviewDetailStock,
+  MarketReviewLadderLevel,
+  MarketReviewLadderResponse
+} from '@/types/market'
+
+const router = useRouter()
 
 const timeRange = ref('30')
+const loading = ref(false)
+const activeStartDate = ref(dayjs().subtract(29, 'day').format('YYYY-MM-DD'))
+const activeEndDate = ref(dayjs().format('YYYY-MM-DD'))
 
-const trendChartRef = ref<HTMLElement>()
-const pieChartRef = ref<HTMLElement>()
-const breakChartRef = ref<HTMLElement>()
-const sectorChartRef = ref<HTMLElement>()
+const dailySeries = ref<string[]>([])
+const dailyRows = ref<MarketReviewDailyRow[]>([])
+const detailResponse = ref<MarketReviewDetailResponse | null>(null)
+const ladderResponse = ref<MarketReviewLadderResponse | null>(null)
 
-let trendChart: echarts.ECharts | null = null
-let pieChart: echarts.ECharts | null = null
-let breakChart: echarts.ECharts | null = null
-let sectorChart: echarts.ECharts | null = null
+const boardHeightChartRef = ref<HTMLElement>()
+const promotionRateChartRef = ref<HTMLElement>()
+const yesterdayChangeChartRef = ref<HTMLElement>()
+const limitTrendChartRef = ref<HTMLElement>()
+const breadthChartRef = ref<HTMLElement>()
+const amountChartRef = ref<HTMLElement>()
 
-// 获取数据
-async function fetchData() {
+let boardHeightChart: echarts.ECharts | null = null
+let promotionRateChart: echarts.ECharts | null = null
+let yesterdayChangeChart: echarts.ECharts | null = null
+let limitTrendChart: echarts.ECharts | null = null
+let breadthChart: echarts.ECharts | null = null
+let amountChart: echarts.ECharts | null = null
+
+const detailStocks = computed(() => detailResponse.value?.stocks ?? [])
+const ladderLevels = computed(() => ladderResponse.value?.ladders ?? [])
+const resolvedTradeDate = computed(
+  () => detailResponse.value?.trade_date || ladderResponse.value?.trade_date || activeEndDate.value
+)
+const hasFallback = computed(
+  () => Boolean(detailResponse.value?.is_fallback || ladderResponse.value?.is_fallback)
+)
+const sealedCloseCount = computed(
+  () => detailStocks.value.filter(stock => stock.today_sealed_close).length
+)
+const openedCloseCount = computed(
+  () => detailStocks.value.filter(stock => stock.today_opened_close).length
+)
+const strongestReason = computed(() => {
+  const counter = new Map<string, number>()
+
+  detailStocks.value.forEach(stock => {
+    if (!stock.limit_up_reason) {
+      return
+    }
+    counter.set(stock.limit_up_reason, (counter.get(stock.limit_up_reason) ?? 0) + 1)
+  })
+
+  let winner = '暂无'
+  let maxCount = 0
+  counter.forEach((count, reason) => {
+    if (count > maxCount) {
+      winner = `${reason} (${count})`
+      maxCount = count
+    }
+  })
+
+  return winner
+})
+
+function getDateRange() {
+  const days = Number.parseInt(timeRange.value, 10)
   const endDate = dayjs().format('YYYY-MM-DD')
-  const startDate = dayjs().subtract(parseInt(timeRange.value), 'day').format('YYYY-MM-DD')
-  
-  try {
-    const [dailyStats, sectorStats] = await Promise.all([
-      getDailyStats({ start_date: startDate, end_date: endDate }),
-      getSectorStats()
-    ])
-    
-    updateTrendChart(dailyStats)
-    updatePieChart(dailyStats[0])
-    updateBreakChart(dailyStats)
-    updateSectorChart(sectorStats)
-  } catch (e) {
-    console.error('Fetch stats error:', e)
+  const startDate = dayjs()
+    .subtract(Math.max(days - 1, 0), 'day')
+    .format('YYYY-MM-DD')
+
+  return { startDate, endDate }
+}
+
+function formatDateLabel(value: string) {
+  return dayjs(value).format('MM-DD')
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (value == null) {
+    return '-'
   }
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(2)}%`
 }
 
-// 更新趋势图
-function updateTrendChart(data: any[]) {
-  if (!trendChart) return
-  
-  const dates = data.map(d => d.trade_date).reverse()
-  const totals = data.map(d => d.total_limit_up).reverse()
-  const news = data.map(d => d.new_limit_up).reverse()
-  
-  trendChart.setOption({
-    tooltip: { trigger: 'axis' },
-    legend: { data: ['涨停总数', '首板数量'] },
-    xAxis: { type: 'category', data: dates },
-    yAxis: { type: 'value' },
-    series: [
-      { name: '涨停总数', type: 'line', data: totals, smooth: true },
-      { name: '首板数量', type: 'line', data: news, smooth: true }
-    ]
-  })
+function formatAmount(value: number) {
+  if (Math.abs(value) >= 100000000) {
+    return `${(value / 100000000).toFixed(2)}亿`
+  }
+  if (Math.abs(value) >= 10000) {
+    return `${(value / 10000).toFixed(2)}万`
+  }
+  return value.toFixed(0)
 }
 
-// 更新饼图
-function updatePieChart(data: any) {
-  if (!pieChart || !data) return
-  
-  pieChart.setOption({
-    tooltip: { trigger: 'item' },
-    series: [{
-      type: 'pie',
-      radius: ['40%', '70%'],
-      data: [
-        { value: data.new_limit_up || 0, name: '首板' },
-        { value: data.continuous_2 || 0, name: '2连板' },
-        { value: data.continuous_3 || 0, name: '3连板' },
-        { value: data.continuous_4_plus || 0, name: '4板+' }
-      ]
-    }]
-  })
+function getChangeClass(value: number | null | undefined) {
+  if (value == null || value === 0) {
+    return 'neutral'
+  }
+  return value > 0 ? 'positive' : 'negative'
 }
 
-// 更新炸板率图
-function updateBreakChart(data: any[]) {
-  if (!breakChart) return
-  
-  const dates = data.map(d => d.trade_date).reverse()
-  const rates = data.map(d => d.break_rate).reverse()
-  
-  breakChart.setOption({
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'category', data: dates },
-    yAxis: { type: 'value', axisLabel: { formatter: '{value}%' } },
-    series: [{
-      type: 'bar',
-      data: rates,
-      itemStyle: { color: '#faad14' }
-    }]
-  })
+function getStockStatusType(stock: MarketReviewDetailStock) {
+  if (stock.today_sealed_close) {
+    return 'danger'
+  }
+  if (stock.today_opened_close) {
+    return 'warning'
+  }
+  return 'info'
 }
 
-// 更新板块图
-function updateSectorChart(data: any[]) {
-  if (!sectorChart) return
-  
-  const sectors = data.slice(0, 10)
-  
-  sectorChart.setOption({
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'value' },
-    yAxis: { 
-      type: 'category', 
-      data: sectors.map(s => s.sector_name).reverse() 
+function getStockStatusLabel(stock: MarketReviewDetailStock) {
+  if (stock.today_sealed_close) {
+    return '封板'
+  }
+  if (stock.today_opened_close) {
+    return '炸板'
+  }
+  return '观察'
+}
+
+function getSealedCount(ladder: MarketReviewLadderLevel) {
+  return ladder.stocks.filter(stock => stock.today_sealed_close).length
+}
+
+function getOpenedCount(ladder: MarketReviewLadderLevel) {
+  return ladder.stocks.filter(stock => stock.today_opened_close).length
+}
+
+function createEmptyOption(): echarts.EChartsOption {
+  return {
+    graphic: {
+      type: 'text',
+      left: 'center',
+      top: 'middle',
+      style: {
+        text: '暂无复盘数据',
+        fill: '#999',
+        fontSize: 14
+      }
     },
-    series: [{
-      type: 'bar',
-      data: sectors.map(s => s.limit_up_count).reverse(),
-      itemStyle: { color: '#f5222d' }
-    }]
-  })
+    xAxis: {
+      type: 'category',
+      data: [],
+      show: false
+    },
+    yAxis: {
+      type: 'value',
+      show: false
+    },
+    series: []
+  }
 }
 
-// 初始化图表
+function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'grid' | 'tooltip' | 'legend' | 'xAxis'> {
+  return {
+    tooltip: {
+      trigger: 'axis'
+    },
+    legend: {
+      top: 0
+    },
+    grid: {
+      left: 56,
+      right: 24,
+      top: 48,
+      bottom: 40
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap,
+      data: dailySeries.value,
+      axisLabel: {
+        color: '#666',
+        formatter: (value: string) => formatDateLabel(value)
+      },
+      axisLine: {
+        lineStyle: {
+          color: '#d9d9d9'
+        }
+      }
+    }
+  }
+}
+
+function updateCharts() {
+  const charts = [
+    boardHeightChart,
+    promotionRateChart,
+    yesterdayChangeChart,
+    limitTrendChart,
+    breadthChart,
+    amountChart
+  ]
+
+  if (!dailyRows.value.length) {
+    charts.forEach(chart => chart?.setOption(createEmptyOption(), true))
+    return
+  }
+
+  boardHeightChart?.setOption(
+    {
+      ...getBaseGridOption(),
+      yAxis: {
+        type: 'value',
+        minInterval: 1
+      },
+      series: [
+        {
+          name: '最高板高度',
+          type: 'line',
+          smooth: true,
+          symbol: 'circle',
+          data: dailyRows.value.map(row => row.max_board_height),
+          itemStyle: { color: '#f5222d' }
+        },
+        {
+          name: '二板家数',
+          type: 'line',
+          smooth: true,
+          symbol: 'circle',
+          data: dailyRows.value.map(row => row.second_board_height),
+          itemStyle: { color: '#fa8c16' }
+        },
+        {
+          name: '创业板涨停',
+          type: 'line',
+          smooth: true,
+          symbol: 'circle',
+          data: dailyRows.value.map(row => row.gem_board_height),
+          itemStyle: { color: '#1677ff' }
+        }
+      ]
+    },
+    true
+  )
+
+  promotionRateChart?.setOption(
+    {
+      ...getBaseGridOption(),
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          formatter: '{value}%'
+        }
+      },
+      series: [
+        {
+          name: '首板晋级率',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.first_to_second_rate),
+          itemStyle: { color: '#f5222d' },
+          areaStyle: {
+            color: 'rgba(245, 34, 45, 0.08)'
+          }
+        },
+        {
+          name: '连板晋级率',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.continuous_promotion_rate),
+          itemStyle: { color: '#722ed1' },
+          areaStyle: {
+            color: 'rgba(114, 46, 209, 0.08)'
+          }
+        },
+        {
+          name: '封板率',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.seal_rate),
+          itemStyle: { color: '#13c2c2' }
+        }
+      ]
+    },
+    true
+  )
+
+  yesterdayChangeChart?.setOption(
+    {
+      ...getBaseGridOption(),
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          formatter: '{value}%'
+        }
+      },
+      series: [
+        {
+          name: '昨日涨停平均涨幅',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.yesterday_limit_up_avg_change),
+          itemStyle: { color: '#ff7875' },
+          barMaxWidth: 28
+        },
+        {
+          name: '昨日连板平均涨幅',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.yesterday_continuous_avg_change),
+          itemStyle: { color: '#52c41a' }
+        }
+      ]
+    },
+    true
+  )
+
+  limitTrendChart?.setOption(
+    {
+      ...getBaseGridOption(true),
+      yAxis: {
+        type: 'value',
+        minInterval: 1
+      },
+      series: [
+        {
+          name: '连板家数',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.continuous_count),
+          itemStyle: { color: '#722ed1' }
+        },
+        {
+          name: '涨停数',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.limit_up_count),
+          itemStyle: { color: '#f5222d' },
+          barMaxWidth: 22
+        },
+        {
+          name: '跌停数',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.limit_down_count),
+          itemStyle: { color: '#52c41a' },
+          barMaxWidth: 22
+        }
+      ]
+    },
+    true
+  )
+
+  breadthChart?.setOption(
+    {
+      ...getBaseGridOption(true),
+      yAxis: [
+        {
+          type: 'value',
+          name: '成交额',
+          axisLabel: {
+            formatter: (value: number) => formatAmount(value)
+          }
+        },
+        {
+          type: 'value',
+          name: '家数',
+          minInterval: 1
+        }
+      ],
+      series: [
+        {
+          name: '沪深成交额',
+          type: 'line',
+          smooth: true,
+          data: dailyRows.value.map(row => row.market_turnover),
+          yAxisIndex: 0,
+          itemStyle: { color: '#1677ff' }
+        },
+        {
+          name: '非ST上涨家数',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.up_count_ex_st),
+          yAxisIndex: 1,
+          itemStyle: { color: '#f5222d' },
+          barMaxWidth: 18
+        },
+        {
+          name: '非ST下跌家数',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.down_count_ex_st),
+          yAxisIndex: 1,
+          itemStyle: { color: '#52c41a' },
+          barMaxWidth: 18
+        }
+      ]
+    },
+    true
+  )
+
+  amountChart?.setOption(
+    {
+      ...getBaseGridOption(true),
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          formatter: (value: number) => formatAmount(value)
+        }
+      },
+      series: [
+        {
+          name: '涨停成交额',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.limit_up_amount),
+          itemStyle: { color: '#f5222d' },
+          barMaxWidth: 26
+        },
+        {
+          name: '炸板成交额',
+          type: 'bar',
+          data: dailyRows.value.map(row => row.broken_amount),
+          itemStyle: { color: '#faad14' },
+          barMaxWidth: 26
+        }
+      ]
+    },
+    true
+  )
+}
+
 function initCharts() {
-  if (trendChartRef.value) {
-    trendChart = echarts.init(trendChartRef.value)
+  if (boardHeightChartRef.value) {
+    boardHeightChart = echarts.init(boardHeightChartRef.value)
   }
-  if (pieChartRef.value) {
-    pieChart = echarts.init(pieChartRef.value)
+  if (promotionRateChartRef.value) {
+    promotionRateChart = echarts.init(promotionRateChartRef.value)
   }
-  if (breakChartRef.value) {
-    breakChart = echarts.init(breakChartRef.value)
+  if (yesterdayChangeChartRef.value) {
+    yesterdayChangeChart = echarts.init(yesterdayChangeChartRef.value)
   }
-  if (sectorChartRef.value) {
-    sectorChart = echarts.init(sectorChartRef.value)
+  if (limitTrendChartRef.value) {
+    limitTrendChart = echarts.init(limitTrendChartRef.value)
+  }
+  if (breadthChartRef.value) {
+    breadthChart = echarts.init(breadthChartRef.value)
+  }
+  if (amountChartRef.value) {
+    amountChart = echarts.init(amountChartRef.value)
   }
 }
 
-watch(timeRange, () => fetchData())
+function resizeCharts() {
+  boardHeightChart?.resize()
+  promotionRateChart?.resize()
+  yesterdayChangeChart?.resize()
+  limitTrendChart?.resize()
+  breadthChart?.resize()
+  amountChart?.resize()
+}
+
+function disposeCharts() {
+  boardHeightChart?.dispose()
+  promotionRateChart?.dispose()
+  yesterdayChangeChart?.dispose()
+  limitTrendChart?.dispose()
+  breadthChart?.dispose()
+  amountChart?.dispose()
+
+  boardHeightChart = null
+  promotionRateChart = null
+  yesterdayChangeChart = null
+  limitTrendChart = null
+  breadthChart = null
+  amountChart = null
+}
+
+async function fetchData() {
+  const { startDate, endDate } = getDateRange()
+  activeStartDate.value = startDate
+  activeEndDate.value = endDate
+  loading.value = true
+
+  try {
+    const [dailyResponse, detail, ladder] = await Promise.all([
+      getMarketReviewDaily({
+        start_date: startDate,
+        end_date: endDate
+      }),
+      getMarketReviewDetail(endDate),
+      getMarketReviewLadder(endDate)
+    ])
+
+    dailySeries.value = dailyResponse.data.series
+    dailyRows.value = dailyResponse.data.rows
+    detailResponse.value = detail
+    ladderResponse.value = ladder
+    updateCharts()
+  } catch (error) {
+    console.error('Fetch market review error:', error)
+    ElMessage.error('获取市场复盘数据失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+function goToDetail(stockCode: string) {
+  router.push(`/stock/${stockCode}`)
+}
+
+function handleRowClick(row: MarketReviewDetailStock) {
+  goToDetail(row.stock_code)
+}
+
+watch(timeRange, () => {
+  fetchData()
+})
 
 onMounted(() => {
   initCharts()
+  updateCharts()
   fetchData()
-  
-  const handleResize = () => {
-    trendChart?.resize()
-    pieChart?.resize()
-    breakChart?.resize()
-    sectorChart?.resize()
-  }
-  window.addEventListener('resize', handleResize)
-  
-  onUnmounted(() => {
-    window.removeEventListener('resize', handleResize)
-    trendChart?.dispose()
-    pieChart?.dispose()
-    breakChart?.dispose()
-    sectorChart?.dispose()
-  })
+  window.addEventListener('resize', resizeCharts)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', resizeCharts)
+  disposeCharts()
 })
 </script>
 
 <style lang="scss" scoped>
 .statistics {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.summary-copy {
+  h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #262626;
+  }
+
+  p {
+    margin: 6px 0 0;
+    color: #666;
+    font-size: 13px;
+  }
+}
+
+.summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: #666;
+  font-size: 13px;
+}
+
+.chart-card,
+.detail-card {
+  margin-bottom: 16px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+
+  h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #262626;
+  }
+
+  p {
+    margin: 6px 0 0;
+    color: #666;
+    font-size: 13px;
+  }
+}
+
+.chart-container {
+  height: 320px;
+}
+
+.detail-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.summary-item {
+  padding: 12px;
+  border-radius: 8px;
+  background: #fafafa;
+
+  .label {
+    display: block;
+    margin-bottom: 6px;
+    color: #8c8c8c;
+    font-size: 12px;
+  }
+
+  strong {
+    color: #262626;
+    font-size: 16px;
+    font-weight: 600;
+  }
+}
+
+.ladder-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ladder-group {
+  padding: 12px;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.ladder-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.days-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 70px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+
+  &.days-2 { background: #1677ff; }
+  &.days-3 { background: #52c41a; }
+  &.days-4 { background: #fa8c16; }
+  &.days-5 { background: #f5222d; }
+  &.days-6 { background: #eb2f96; }
+  &.days-7 { background: #722ed1; }
+  &.days-8 { background: #13c2c2; }
+  &.days-9 { background: #2f54eb; }
+  &.days-10 { background: #a61d24; }
+}
+
+.count {
+  color: #595959;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.ladder-stat {
+  color: #f5222d;
+  font-size: 12px;
+}
+
+.ladder-stat-warning {
+  color: #fa8c16;
+}
+
+.stock-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stock-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  border-radius: 6px;
+  background: #fff;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #f0f7ff;
+  }
+
+  .code {
+    color: #1677ff;
+    font-size: 12px;
+    font-family: monospace;
+  }
+
+  .name {
+    color: #262626;
+    font-size: 13px;
+    font-weight: 500;
+  }
+}
+
+.stock-cell {
+  display: flex;
+  flex-direction: column;
+
+  .name {
+    color: #262626;
+    font-weight: 500;
+  }
+
+  .code {
+    color: #1677ff;
+    font-size: 12px;
+    font-family: monospace;
+  }
+}
+
+.positive {
+  color: #f5222d;
+  font-weight: 500;
+}
+
+.negative {
+  color: #52c41a;
+  font-weight: 500;
+}
+
+.neutral {
+  color: #8c8c8c;
+}
+
+@media (max-width: 991px) {
+  .detail-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
   .card {
-    background: #fff;
-    border-radius: 8px;
-    padding: 16px;
-    margin-bottom: 16px;
+    padding: 14px;
+  }
 
-    .card-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 16px;
+  .chart-container {
+    height: 280px;
+  }
 
-      h3 {
-        margin: 0;
-        font-size: 16px;
-      }
-    }
-
-    .chart-container {
-      height: 300px;
-    }
+  .detail-summary {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -245,6 +245,7 @@ const activeEndDate = ref(dayjs().format('YYYY-MM-DD'))
 
 const dailySeries = ref<string[]>([])
 const dailyRows = ref<MarketReviewDailyRow[]>([])
+const dailyHasFallback = ref(false)
 const detailResponse = ref<MarketReviewDetailResponse | null>(null)
 const ladderResponse = ref<MarketReviewLadderResponse | null>(null)
 
@@ -269,7 +270,7 @@ const resolvedTradeDate = computed(
   () => detailResponse.value?.trade_date || ladderResponse.value?.trade_date || activeEndDate.value
 )
 const hasFallback = computed(
-  () => Boolean(detailResponse.value?.is_fallback || ladderResponse.value?.is_fallback)
+  () => Boolean(dailyHasFallback.value || detailResponse.value?.is_fallback || ladderResponse.value?.is_fallback)
 )
 const sealedCloseCount = computed(
   () => detailStocks.value.filter(stock => stock.today_sealed_close).length
@@ -707,32 +708,43 @@ async function fetchData() {
   const currentSequence = ++fetchSequence
   loading.value = true
 
-  const [dailyResult, detailResult, ladderResult] = await Promise.allSettled([
-    getMarketReviewDaily({
+  let detailDate = endDate
+  let hasError = false
+
+  try {
+    const dailyResult = await getMarketReviewDaily({
       start_date: startDate,
       end_date: endDate
-    }),
-    getMarketReviewDetail(endDate),
-    getMarketReviewLadder(endDate)
+    })
+
+    if (currentSequence !== fetchSequence) {
+      return
+    }
+
+    dailySeries.value = dailyResult.data.series
+    dailyRows.value = dailyResult.data.rows
+    dailyHasFallback.value = Boolean(dailyResult.is_fallback)
+    const lastSeriesDate = dailyResult.data.series[dailyResult.data.series.length - 1]
+    activeStartDate.value = dailyResult.start_date || startDate
+    activeEndDate.value = dailyResult.end_date || lastSeriesDate || endDate
+    detailDate = activeEndDate.value
+  } catch (e) {
+    console.error('Fetch market review daily error:', e)
+    dailySeries.value = []
+    dailyRows.value = []
+    dailyHasFallback.value = false
+    activeStartDate.value = startDate
+    activeEndDate.value = endDate
+    hasError = true
+  }
+
+  const [detailResult, ladderResult] = await Promise.allSettled([
+    getMarketReviewDetail(detailDate),
+    getMarketReviewLadder(detailDate)
   ])
 
   if (currentSequence !== fetchSequence) {
     return
-  }
-
-  activeStartDate.value = startDate
-  activeEndDate.value = endDate
-
-  let hasError = false
-
-  if (dailyResult.status === 'fulfilled') {
-    dailySeries.value = dailyResult.value.data.series
-    dailyRows.value = dailyResult.value.data.rows
-  } else {
-    console.error('Fetch market review daily error:', dailyResult.reason)
-    dailySeries.value = []
-    dailyRows.value = []
-    hasError = true
   }
 
   if (detailResult.status === 'fulfilled') {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -228,6 +228,7 @@ import { ElMessage } from 'element-plus'
 import * as echarts from 'echarts'
 import dayjs from 'dayjs'
 import { getMarketReviewDaily, getMarketReviewDetail, getMarketReviewLadder } from '@/api'
+import { buildReviewRange } from '@/utils/reviewRange'
 import type {
   MarketReviewDailyRow,
   MarketReviewDetailResponse,
@@ -240,7 +241,7 @@ const router = useRouter()
 
 const timeRange = ref('30')
 const loading = ref(false)
-const activeStartDate = ref(dayjs().subtract(29, 'day').format('YYYY-MM-DD'))
+const activeStartDate = ref(dayjs().format('YYYY-MM-DD'))
 const activeEndDate = ref(dayjs().format('YYYY-MM-DD'))
 
 const dailySeries = ref<string[]>([])
@@ -301,33 +302,7 @@ const strongestReason = computed(() => {
 })
 
 function getDateRange() {
-  const days = Number.parseInt(timeRange.value, 10)
-  const endDate = dayjs().format('YYYY-MM-DD')
-
-  if (timeRange.value === '90') {
-    const startDate = dayjs().subtract(3, 'month').format('YYYY-MM-DD')
-    return {
-      startDate,
-      endDate,
-      query: {
-        start_date: startDate,
-        end_date: endDate
-      }
-    }
-  }
-
-  const startDate = dayjs()
-    .subtract(Math.max(days - 1, 0), 'day')
-    .format('YYYY-MM-DD')
-
-  return {
-    startDate,
-    endDate,
-    query: {
-      days,
-      end_date: endDate
-    }
-  }
+  return buildReviewRange(timeRange.value, dayjs().format('YYYY-MM-DD'))
 }
 
 function formatDateLabel(value: string) {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -303,11 +303,31 @@ const strongestReason = computed(() => {
 function getDateRange() {
   const days = Number.parseInt(timeRange.value, 10)
   const endDate = dayjs().format('YYYY-MM-DD')
+
+  if (timeRange.value === '90') {
+    const startDate = dayjs().subtract(3, 'month').format('YYYY-MM-DD')
+    return {
+      startDate,
+      endDate,
+      query: {
+        start_date: startDate,
+        end_date: endDate
+      }
+    }
+  }
+
   const startDate = dayjs()
     .subtract(Math.max(days - 1, 0), 'day')
     .format('YYYY-MM-DD')
 
-  return { startDate, endDate }
+  return {
+    startDate,
+    endDate,
+    query: {
+      days,
+      end_date: endDate
+    }
+  }
 }
 
 function formatDateLabel(value: string) {
@@ -704,7 +724,7 @@ function disposeCharts() {
 }
 
 async function fetchData() {
-  const { startDate, endDate } = getDateRange()
+  const { startDate, endDate, query } = getDateRange()
   const currentSequence = ++fetchSequence
   loading.value = true
 
@@ -712,10 +732,7 @@ async function fetchData() {
   let hasError = false
 
   try {
-    const dailyResult = await getMarketReviewDaily({
-      start_date: startDate,
-      end_date: endDate
-    })
+    const dailyResult = await getMarketReviewDaily(query)
 
     if (currentSequence !== fetchSequence) {
       return

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -29,7 +29,7 @@
           <div class="card-header">
             <div>
               <h3>连板高度</h3>
-              <p>龙头高度、二板家数与创业板涨停梯度。</p>
+              <p>龙头高度、次高板高度与创业板高度。</p>
             </div>
           </div>
           <div ref="boardHeightChartRef" class="chart-container"></div>
@@ -261,6 +261,7 @@ let yesterdayChangeChart: echarts.ECharts | null = null
 let limitTrendChart: echarts.ECharts | null = null
 let breadthChart: echarts.ECharts | null = null
 let amountChart: echarts.ECharts | null = null
+let fetchSequence = 0
 
 const detailStocks = computed(() => detailResponse.value?.stocks ?? [])
 const ladderLevels = computed(() => ladderResponse.value?.ladders ?? [])
@@ -453,7 +454,7 @@ function updateCharts() {
           itemStyle: { color: '#f5222d' }
         },
         {
-          name: '二板家数',
+          name: '次高板高度',
           type: 'line',
           smooth: true,
           symbol: 'circle',
@@ -461,7 +462,7 @@ function updateCharts() {
           itemStyle: { color: '#fa8c16' }
         },
         {
-          name: '创业板涨停',
+          name: '创业板高度',
           type: 'line',
           smooth: true,
           symbol: 'circle',
@@ -703,29 +704,60 @@ function disposeCharts() {
 
 async function fetchData() {
   const { startDate, endDate } = getDateRange()
-  activeStartDate.value = startDate
-  activeEndDate.value = endDate
+  const currentSequence = ++fetchSequence
   loading.value = true
 
-  try {
-    const [dailyResponse, detail, ladder] = await Promise.all([
-      getMarketReviewDaily({
-        start_date: startDate,
-        end_date: endDate
-      }),
-      getMarketReviewDetail(endDate),
-      getMarketReviewLadder(endDate)
-    ])
+  const [dailyResult, detailResult, ladderResult] = await Promise.allSettled([
+    getMarketReviewDaily({
+      start_date: startDate,
+      end_date: endDate
+    }),
+    getMarketReviewDetail(endDate),
+    getMarketReviewLadder(endDate)
+  ])
 
-    dailySeries.value = dailyResponse.data.series
-    dailyRows.value = dailyResponse.data.rows
-    detailResponse.value = detail
-    ladderResponse.value = ladder
-    updateCharts()
-  } catch (error) {
-    console.error('Fetch market review error:', error)
+  if (currentSequence !== fetchSequence) {
+    return
+  }
+
+  activeStartDate.value = startDate
+  activeEndDate.value = endDate
+
+  let hasError = false
+
+  if (dailyResult.status === 'fulfilled') {
+    dailySeries.value = dailyResult.value.data.series
+    dailyRows.value = dailyResult.value.data.rows
+  } else {
+    console.error('Fetch market review daily error:', dailyResult.reason)
+    dailySeries.value = []
+    dailyRows.value = []
+    hasError = true
+  }
+
+  if (detailResult.status === 'fulfilled') {
+    detailResponse.value = detailResult.value
+  } else {
+    console.error('Fetch market review detail error:', detailResult.reason)
+    detailResponse.value = null
+    hasError = true
+  }
+
+  if (ladderResult.status === 'fulfilled') {
+    ladderResponse.value = ladderResult.value
+  } else {
+    console.error('Fetch market review ladder error:', ladderResult.reason)
+    ladderResponse.value = null
+    hasError = true
+  }
+
+  updateCharts()
+
+  if (hasError) {
     ElMessage.error('获取市场复盘数据失败')
-  } finally {
+  }
+
+  if (currentSequence === fetchSequence) {
     loading.value = false
   }
 }

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -398,7 +398,7 @@ function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'gr
     grid: {
       left: 56,
       right: 24,
-      top: 48,
+      top: 64,
       bottom: 40
     },
     xAxis: {
@@ -415,6 +415,27 @@ function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'gr
         }
       }
     }
+  }
+}
+
+type BoardLabelField = 'max_board_label' | 'second_board_label' | 'gem_board_label'
+
+function getBoardLabelFormatter(field: BoardLabelField) {
+  return (params: { dataIndex?: number }) => {
+    const row = params.dataIndex == null ? null : dailyRows.value[params.dataIndex]
+    return row?.[field] || ''
+  }
+}
+
+function getBoardHeightLabelOption(field: BoardLabelField, position: 'top' | 'bottom' = 'top') {
+  return {
+    show: true,
+    position,
+    formatter: getBoardLabelFormatter(field),
+    color: '#262626',
+    fontSize: 12,
+    lineHeight: 16,
+    distance: 8
   }
 }
 
@@ -447,7 +468,8 @@ function updateCharts() {
           smooth: true,
           symbol: 'circle',
           data: dailyRows.value.map(row => row.max_board_height),
-          itemStyle: { color: '#f5222d' }
+          itemStyle: { color: '#f5222d' },
+          label: getBoardHeightLabelOption('max_board_label')
         },
         {
           name: '次高板高度',
@@ -455,7 +477,8 @@ function updateCharts() {
           smooth: true,
           symbol: 'circle',
           data: dailyRows.value.map(row => row.second_board_height),
-          itemStyle: { color: '#fa8c16' }
+          itemStyle: { color: '#fa8c16' },
+          label: getBoardHeightLabelOption('second_board_label')
         },
         {
           name: '创业板高度',
@@ -463,7 +486,8 @@ function updateCharts() {
           smooth: true,
           symbol: 'circle',
           data: dailyRows.value.map(row => row.gem_board_height),
-          itemStyle: { color: '#1677ff' }
+          itemStyle: { color: '#1677ff' },
+          label: getBoardHeightLabelOption('gem_board_label', 'bottom')
         }
       ]
     },

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -115,12 +115,6 @@
                   {{ ladder.continuous_days }}连板
                 </span>
                 <span class="count">{{ ladder.count }}只</span>
-                <span class="ladder-stat">封板 {{ getSealedCount(ladder) }}</span>
-                <span class="ladder-stat ladder-stat-warning">炸板 {{ getOpenedCount(ladder) }}</span>
-                <span class="ladder-stat ladder-stat-rate">封板率 {{ getLadderSealRate(ladder) }}</span>
-                <span class="ladder-stat ladder-stat-average" :class="getChangeClass(getLadderAverageChangeValue(ladder))">
-                  均涨 {{ getLadderAverageChange(ladder) }}
-                </span>
               </div>
 
               <div class="stock-chip-list">
@@ -237,7 +231,6 @@ import type {
   MarketReviewDailyRow,
   MarketReviewDetailResponse,
   MarketReviewDetailStock,
-  MarketReviewLadderLevel,
   MarketReviewLadderResponse
 } from '@/types/market'
 
@@ -358,37 +351,6 @@ function getStockStatusLabel(stock: MarketReviewDetailStock) {
   return '观察'
 }
 
-function getSealedCount(ladder: MarketReviewLadderLevel) {
-  return ladder.stocks.filter(stock => stock.today_sealed_close).length
-}
-
-function getOpenedCount(ladder: MarketReviewLadderLevel) {
-  return ladder.stocks.filter(stock => stock.today_opened_close).length
-}
-
-function getLadderSealRate(ladder: MarketReviewLadderLevel) {
-  const total = ladder.count || ladder.stocks.length
-  if (!total) {
-    return '0.00%'
-  }
-  return `${((getSealedCount(ladder) / total) * 100).toFixed(2)}%`
-}
-
-function getLadderAverageChangeValue(ladder: MarketReviewLadderLevel) {
-  const changes = ladder.stocks
-    .map(stock => stock.change_pct)
-    .filter((value): value is number => value != null)
-
-  if (!changes.length) {
-    return null
-  }
-  return changes.reduce((sum, value) => sum + value, 0) / changes.length
-}
-
-function getLadderAverageChange(ladder: MarketReviewLadderLevel) {
-  return formatPercent(getLadderAverageChangeValue(ladder))
-}
-
 function createEmptyOption(): echarts.EChartsOption {
   return {
     graphic: {
@@ -448,6 +410,7 @@ function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'gr
 type BoardLabelField = 'max_board_label' | 'second_board_label' | 'gem_board_label'
 type BoardHeightField = 'max_board_height' | 'second_board_height' | 'gem_board_height'
 
+const boardLabelFields: BoardLabelField[] = ['max_board_label', 'second_board_label', 'gem_board_label']
 const boardHeightFieldMap: Record<BoardLabelField, BoardHeightField> = {
   max_board_label: 'max_board_height',
   second_board_label: 'second_board_height',
@@ -456,10 +419,51 @@ const boardHeightFieldMap: Record<BoardLabelField, BoardHeightField> = {
 
 function compactBoardLabel(label: string) {
   const lines = label.split('\n').filter(Boolean)
-  if (lines.length <= 2) {
-    return lines.join('\n')
+  if (lines.length <= 1) {
+    return lines[0] || ''
   }
-  return `${lines.slice(0, 2).join('\n')}\n等${lines.length}只`
+  return `${lines[0]} 等${lines.length}只`
+}
+
+function getBoardHeight(row: MarketReviewDailyRow | undefined, field: BoardLabelField) {
+  return Number(row?.[boardHeightFieldMap[field]] || 0)
+}
+
+function isDominantBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
+  const row = dailyRows.value[rowIndex]
+  if (!row) {
+    return false
+  }
+
+  const currentHeight = getBoardHeight(row, field)
+  const currentOrder = boardLabelFields.indexOf(field)
+
+  return boardLabelFields.every((candidate, candidateOrder) => {
+    if (candidate === field || !row[candidate]) {
+      return true
+    }
+
+    const candidateHeight = getBoardHeight(row, candidate)
+    return currentHeight > candidateHeight || (currentHeight === candidateHeight && currentOrder < candidateOrder)
+  })
+}
+
+function isSparseBoardHeightLabelPoint(rowIndex: number, field: BoardLabelField) {
+  const row = dailyRows.value[rowIndex]
+  const currentHeight = getBoardHeight(row, field)
+  if (currentHeight < 2) {
+    return false
+  }
+
+  const prevHeight = getBoardHeight(dailyRows.value[rowIndex - 1], field)
+  const nextHeight = getBoardHeight(dailyRows.value[rowIndex + 1], field)
+  const isLastPoint = rowIndex === dailyRows.value.length - 1
+  const isStrictPeak = currentHeight > prevHeight && currentHeight > nextHeight
+
+  if (isLastPoint) {
+    return field === 'max_board_label' && currentHeight >= 3
+  }
+  return isStrictPeak && currentHeight >= (field === 'max_board_label' ? 4 : 3)
 }
 
 function shouldShowBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
@@ -467,27 +471,10 @@ function shouldShowBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
   if (!row?.[field]) {
     return false
   }
-
-  const heightField = boardHeightFieldMap[field]
-  const currentHeight = Number(row[heightField] || 0)
-  if (currentHeight < 2) {
+  if (!isDominantBoardHeightLabel(rowIndex, field)) {
     return false
   }
-
-  const prevHeight = Number(dailyRows.value[rowIndex - 1]?.[heightField] || 0)
-  const nextHeight = Number(dailyRows.value[rowIndex + 1]?.[heightField] || 0)
-  const isLastPoint = rowIndex === dailyRows.value.length - 1
-  const isLocalPeak = currentHeight >= prevHeight && currentHeight >= nextHeight && (
-    currentHeight > prevHeight || currentHeight > nextHeight
-  )
-
-  if (isLastPoint) {
-    return field !== 'gem_board_label' || currentHeight >= 2
-  }
-  if (field === 'max_board_label') {
-    return isLocalPeak || currentHeight >= 5
-  }
-  return isLocalPeak && currentHeight >= 3
+  return isSparseBoardHeightLabelPoint(rowIndex, field)
 }
 
 function getBoardLabelFormatter(field: BoardLabelField) {
@@ -508,7 +495,9 @@ function getBoardHeightLabelOption(field: BoardLabelField, position: 'top' | 'bo
     color: '#262626',
     fontSize: 12,
     lineHeight: 16,
-    distance: 8
+    distance: 8,
+    width: 110,
+    overflow: 'truncate'
   }
 }
 
@@ -571,6 +560,9 @@ function updateCharts() {
           symbol: 'circle',
           data: dailyRows.value.map(row => row.max_board_height),
           itemStyle: { color: '#f5222d' },
+          labelLayout: {
+            hideOverlap: true
+          },
           label: getBoardHeightLabelOption('max_board_label')
         },
         {
@@ -580,6 +572,9 @@ function updateCharts() {
           symbol: 'circle',
           data: dailyRows.value.map(row => row.second_board_height),
           itemStyle: { color: '#fa8c16' },
+          labelLayout: {
+            hideOverlap: true
+          },
           label: getBoardHeightLabelOption('second_board_label')
         },
         {
@@ -589,6 +584,9 @@ function updateCharts() {
           symbol: 'circle',
           data: dailyRows.value.map(row => row.gem_board_height),
           itemStyle: { color: '#1677ff' },
+          labelLayout: {
+            hideOverlap: true
+          },
           label: getBoardHeightLabelOption('gem_board_label', 'bottom')
         }
       ]
@@ -1071,31 +1069,6 @@ onUnmounted(() => {
   color: #595959;
   font-size: 13px;
   font-weight: 500;
-}
-
-.ladder-stat {
-  color: #f5222d;
-  font-size: 12px;
-}
-
-.ladder-stat-warning {
-  color: #fa8c16;
-}
-
-.ladder-stat-rate {
-  color: #1677ff;
-}
-
-.ladder-stat-average.positive {
-  color: #f5222d;
-}
-
-.ladder-stat-average.negative {
-  color: #52c41a;
-}
-
-.ladder-stat-average.neutral {
-  color: #8c8c8c;
 }
 
 .stock-chip-list {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -7,16 +7,30 @@
           <p>用复盘指标跟踪连板高度、晋级率、情绪与量能变化。</p>
         </div>
 
-        <el-radio-group v-model="timeRange" size="small">
-          <el-radio-button label="7">近7天</el-radio-button>
-          <el-radio-button label="30">近30天</el-radio-button>
-          <el-radio-button label="3m">近3月</el-radio-button>
-        </el-radio-group>
+        <div class="summary-controls">
+          <el-radio-group v-model="reviewMode" size="small">
+            <el-radio-button label="daily">收盘复盘</el-radio-button>
+            <el-radio-button label="intraday">盘中实时</el-radio-button>
+          </el-radio-group>
+
+          <el-radio-group v-if="reviewMode === 'daily'" v-model="timeRange" size="small">
+            <el-radio-button label="7">近7天</el-radio-button>
+            <el-radio-button label="30">近30天</el-radio-button>
+            <el-radio-button label="3m">近3月</el-radio-button>
+          </el-radio-group>
+        </div>
       </div>
 
       <div class="summary-meta">
-        <span>区间 {{ activeStartDate }} 至 {{ activeEndDate }}</span>
+        <span v-if="reviewMode === 'daily'">区间 {{ activeStartDate }} 至 {{ activeEndDate }}</span>
+        <span v-else>盘中快照 {{ activeEndDate }}</span>
         <span>明细日期 {{ resolvedTradeDate }}</span>
+        <span v-if="reviewMode === 'intraday' && intradaySnapshotTime">
+          更新时间 {{ formatSnapshotTime(intradaySnapshotTime) }}
+        </span>
+        <el-tag v-if="reviewMode === 'intraday'" type="success" size="small">
+          盘中快照
+        </el-tag>
         <el-tag v-if="hasFallback" type="warning" size="small">
           已回退到最近可用数据
         </el-tag>
@@ -240,7 +254,7 @@ import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import * as echarts from 'echarts'
 import dayjs from 'dayjs'
-import { getMarketReviewDaily, getMarketReviewDetail, getMarketReviewLadder } from '@/api'
+import { getMarketReviewDaily, getMarketReviewDetail, getMarketReviewIntraday, getMarketReviewLadder } from '@/api'
 import { buildReviewRange } from '@/utils/reviewRange'
 import type {
   MarketReviewDailyRow,
@@ -252,6 +266,7 @@ import type {
 
 const router = useRouter()
 
+const reviewMode = ref<'daily' | 'intraday'>('daily')
 const timeRange = ref('30')
 const loading = ref(false)
 const activeStartDate = ref(dayjs().format('YYYY-MM-DD'))
@@ -262,6 +277,7 @@ const dailyRows = ref<MarketReviewDailyRow[]>([])
 const dailyHasFallback = ref(false)
 const detailResponse = ref<MarketReviewDetailResponse | null>(null)
 const ladderResponse = ref<MarketReviewLadderResponse | null>(null)
+const intradaySnapshotTime = ref<string | null>(null)
 
 const boardHeightChartRef = ref<HTMLElement>()
 const promotionRateChartRef = ref<HTMLElement>()
@@ -277,6 +293,7 @@ let limitTrendChart: echarts.ECharts | null = null
 let breadthChart: echarts.ECharts | null = null
 let amountChart: echarts.ECharts | null = null
 let fetchSequence = 0
+let intradayRefreshTimer: number | null = null
 
 const detailStocks = computed(() => detailResponse.value?.stocks ?? [])
 const ladderLevels = computed(() => ladderResponse.value?.ladders ?? [])
@@ -320,6 +337,10 @@ function getDateRange() {
 
 function formatDateLabel(value: string) {
   return dayjs(value).format('MM-DD')
+}
+
+function formatSnapshotTime(value: string) {
+  return dayjs(value).format('HH:mm:ss')
 }
 
 function formatPercent(value: number | null | undefined) {
@@ -963,9 +984,58 @@ function disposeCharts() {
 }
 
 async function fetchData() {
-  const { startDate, endDate, query } = getDateRange()
   const currentSequence = ++fetchSequence
   loading.value = true
+  const today = dayjs().format('YYYY-MM-DD')
+
+  if (reviewMode.value === 'intraday') {
+    let hasError = false
+
+    try {
+      const dailyResult = await getMarketReviewIntraday(dayjs().format('YYYY-MM-DD'))
+
+      if (currentSequence !== fetchSequence) {
+        return
+      }
+
+      dailySeries.value = dailyResult.data.series
+      dailyRows.value = dailyResult.data.rows
+      dailyHasFallback.value = Boolean(dailyResult.is_fallback)
+      const snapshotDate = dailyResult.end_date || dailyResult.latest_trade_date || dailyResult.data.series[0] || today
+      activeStartDate.value = snapshotDate
+      activeEndDate.value = snapshotDate
+      intradaySnapshotTime.value = dailyResult.snapshot_time
+      detailResponse.value = dailyResult.detail
+      ladderResponse.value = dailyResult.ladder
+    } catch (e) {
+      console.error('Fetch market review intraday error:', e)
+      dailySeries.value = []
+      dailyRows.value = []
+      dailyHasFallback.value = false
+      detailResponse.value = null
+      ladderResponse.value = null
+      intradaySnapshotTime.value = null
+      activeStartDate.value = today
+      activeEndDate.value = today
+      hasError = true
+    }
+
+    if (currentSequence !== fetchSequence) {
+      return
+    }
+
+    updateCharts()
+
+    if (hasError) {
+      ElMessage.error('获取盘中复盘数据失败')
+    }
+
+    loading.value = false
+    return
+  }
+
+  const { startDate, endDate, query } = getDateRange()
+  intradaySnapshotTime.value = null
 
   let detailDate = endDate
   let hasError = false
@@ -1039,17 +1109,41 @@ function handleRowClick(row: MarketReviewDetailStock) {
 }
 
 watch(timeRange, () => {
+  if (reviewMode.value === 'daily') {
+    fetchData()
+  }
+})
+
+function clearIntradayRefreshTimer() {
+  if (intradayRefreshTimer != null) {
+    window.clearInterval(intradayRefreshTimer)
+    intradayRefreshTimer = null
+  }
+}
+
+function resetIntradayRefreshTimer() {
+  clearIntradayRefreshTimer()
+  if (reviewMode.value === 'intraday') {
+    intradayRefreshTimer = window.setInterval(fetchData, 60000)
+  }
+}
+
+watch(reviewMode, () => {
+  clearIntradayRefreshTimer()
   fetchData()
+  resetIntradayRefreshTimer()
 })
 
 onMounted(() => {
   initCharts()
   updateCharts()
   fetchData()
+  resetIntradayRefreshTimer()
   window.addEventListener('resize', resizeCharts)
 })
 
 onUnmounted(() => {
+  clearIntradayRefreshTimer()
   window.removeEventListener('resize', resizeCharts)
   disposeCharts()
 })
@@ -1104,6 +1198,14 @@ onUnmounted(() => {
   flex-wrap: wrap;
   color: #666;
   font-size: 13px;
+}
+
+.summary-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .chart-card,

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -548,15 +548,17 @@ function updateCharts() {
       series: [
         {
           name: '昨日涨停平均涨幅',
-          type: 'bar',
+          type: 'line',
+          smooth: false,
+          symbol: 'circle',
           data: dailyRows.value.map(row => row.yesterday_limit_up_avg_change),
-          itemStyle: { color: '#ff7875' },
-          barMaxWidth: 28
+          itemStyle: { color: '#ff7875' }
         },
         {
           name: '昨日连板平均涨幅',
           type: 'line',
-          smooth: true,
+          smooth: false,
+          symbol: 'circle',
           data: dailyRows.value.map(row => row.yesterday_continuous_avg_change),
           itemStyle: { color: '#52c41a' }
         }

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -117,6 +117,10 @@
                 <span class="count">{{ ladder.count }}只</span>
                 <span class="ladder-stat">封板 {{ getSealedCount(ladder) }}</span>
                 <span class="ladder-stat ladder-stat-warning">炸板 {{ getOpenedCount(ladder) }}</span>
+                <span class="ladder-stat ladder-stat-rate">封板率 {{ getLadderSealRate(ladder) }}</span>
+                <span class="ladder-stat ladder-stat-average" :class="getChangeClass(getLadderAverageChangeValue(ladder))">
+                  均涨 {{ getLadderAverageChange(ladder) }}
+                </span>
               </div>
 
               <div class="stock-chip-list">
@@ -362,6 +366,29 @@ function getOpenedCount(ladder: MarketReviewLadderLevel) {
   return ladder.stocks.filter(stock => stock.today_opened_close).length
 }
 
+function getLadderSealRate(ladder: MarketReviewLadderLevel) {
+  const total = ladder.count || ladder.stocks.length
+  if (!total) {
+    return '0.00%'
+  }
+  return `${((getSealedCount(ladder) / total) * 100).toFixed(2)}%`
+}
+
+function getLadderAverageChangeValue(ladder: MarketReviewLadderLevel) {
+  const changes = ladder.stocks
+    .map(stock => stock.change_pct)
+    .filter((value): value is number => value != null)
+
+  if (!changes.length) {
+    return null
+  }
+  return changes.reduce((sum, value) => sum + value, 0) / changes.length
+}
+
+function getLadderAverageChange(ladder: MarketReviewLadderLevel) {
+  return formatPercent(getLadderAverageChangeValue(ladder))
+}
+
 function createEmptyOption(): echarts.EChartsOption {
   return {
     graphic: {
@@ -419,11 +446,57 @@ function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'gr
 }
 
 type BoardLabelField = 'max_board_label' | 'second_board_label' | 'gem_board_label'
+type BoardHeightField = 'max_board_height' | 'second_board_height' | 'gem_board_height'
+
+const boardHeightFieldMap: Record<BoardLabelField, BoardHeightField> = {
+  max_board_label: 'max_board_height',
+  second_board_label: 'second_board_height',
+  gem_board_label: 'gem_board_height'
+}
+
+function compactBoardLabel(label: string) {
+  const lines = label.split('\n').filter(Boolean)
+  if (lines.length <= 2) {
+    return lines.join('\n')
+  }
+  return `${lines.slice(0, 2).join('\n')}\n等${lines.length}只`
+}
+
+function shouldShowBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
+  const row = dailyRows.value[rowIndex]
+  if (!row?.[field]) {
+    return false
+  }
+
+  const heightField = boardHeightFieldMap[field]
+  const currentHeight = Number(row[heightField] || 0)
+  if (currentHeight < 2) {
+    return false
+  }
+
+  const prevHeight = Number(dailyRows.value[rowIndex - 1]?.[heightField] || 0)
+  const nextHeight = Number(dailyRows.value[rowIndex + 1]?.[heightField] || 0)
+  const isLastPoint = rowIndex === dailyRows.value.length - 1
+  const isLocalPeak = currentHeight >= prevHeight && currentHeight >= nextHeight && (
+    currentHeight > prevHeight || currentHeight > nextHeight
+  )
+
+  if (isLastPoint) {
+    return field !== 'gem_board_label' || currentHeight >= 2
+  }
+  if (field === 'max_board_label') {
+    return isLocalPeak || currentHeight >= 5
+  }
+  return isLocalPeak && currentHeight >= 3
+}
 
 function getBoardLabelFormatter(field: BoardLabelField) {
   return (params: { dataIndex?: number }) => {
     const row = params.dataIndex == null ? null : dailyRows.value[params.dataIndex]
-    return row?.[field] || ''
+    if (!row || params.dataIndex == null || !shouldShowBoardHeightLabel(params.dataIndex, field)) {
+      return ''
+    }
+    return compactBoardLabel(row[field] || '')
   }
 }
 
@@ -437,6 +510,31 @@ function getBoardHeightLabelOption(field: BoardLabelField, position: 'top' | 'bo
     lineHeight: 16,
     distance: 8
   }
+}
+
+function formatBoardHeightTooltip(params: unknown) {
+  const items = Array.isArray(params) ? params : [params]
+  const dataIndex = Number((items[0] as { dataIndex?: number } | undefined)?.dataIndex ?? -1)
+  const row = dailyRows.value[dataIndex]
+  if (!row) {
+    return ''
+  }
+
+  const metricLines = items.map(item => {
+    const point = item as { marker?: string; seriesName?: string; value?: number | string }
+    return `${point.marker || ''}${point.seriesName || ''}: ${point.value ?? '-'}`
+  })
+  const stockLines = [
+    row.max_board_label ? `最高板：${row.max_board_label.replace(/\n/g, '、')}` : '',
+    row.second_board_label ? `次高板：${row.second_board_label.replace(/\n/g, '、')}` : '',
+    row.gem_board_label ? `创业板：${row.gem_board_label.replace(/\n/g, '、')}` : ''
+  ].filter(Boolean)
+
+  return [
+    formatDateLabel(row.trade_date),
+    ...metricLines,
+    ...stockLines
+  ].join('<br/>')
 }
 
 function updateCharts() {
@@ -457,6 +555,10 @@ function updateCharts() {
   boardHeightChart?.setOption(
     {
       ...getBaseGridOption(),
+      tooltip: {
+        trigger: 'axis',
+        formatter: formatBoardHeightTooltip
+      },
       yAxis: {
         type: 'value',
         minInterval: 1
@@ -978,6 +1080,22 @@ onUnmounted(() => {
 
 .ladder-stat-warning {
   color: #fa8c16;
+}
+
+.ladder-stat-rate {
+  color: #1677ff;
+}
+
+.ladder-stat-average.positive {
+  color: #f5222d;
+}
+
+.ladder-stat-average.negative {
+  color: #52c41a;
+}
+
+.ladder-stat-average.neutral {
+  color: #8c8c8c;
 }
 
 .stock-chip-list {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -32,7 +32,7 @@
               <p>龙头高度、次高板高度与创业板高度。</p>
             </div>
           </div>
-          <div ref="boardHeightChartRef" class="chart-container board-height-chart"></div>
+          <div ref="boardHeightChartRef" class="chart-container review-main-chart"></div>
         </div>
       </el-col>
       <el-col :xs="24" :lg="12">
@@ -43,7 +43,7 @@
               <p>首板进二板、连板晋级与封板率联动观察。</p>
             </div>
           </div>
-          <div ref="promotionRateChartRef" class="chart-container"></div>
+          <div ref="promotionRateChartRef" class="chart-container review-main-chart"></div>
         </div>
       </el-col>
     </el-row>
@@ -497,10 +497,10 @@ const boardHeightFieldMap: Record<BoardLabelField, BoardHeightField> = {
 
 function compactBoardLabel(label: string) {
   const lines = label.split('\n').filter(Boolean)
-  if (lines.length <= 1) {
-    return lines[0] || ''
+  if (lines.length <= 3) {
+    return lines.join('\n')
   }
-  return `${lines[0]} 等${lines.length}只`
+  return `${lines.slice(0, 3).join('\n')}\n等${lines.length}只`
 }
 
 function getBoardHeight(row: MarketReviewDailyRow | undefined, field: BoardLabelField) {
@@ -558,11 +558,8 @@ function getBoardHeightLabelOption(
     fontSize: 11,
     lineHeight: 14,
     distance: 6,
-    width: 100,
-    overflow: 'truncate',
-    backgroundColor: 'rgba(255, 255, 255, 0.86)',
-    borderRadius: 4,
-    padding: [2, 4]
+    width: 118,
+    overflow: 'break'
   }
 }
 
@@ -1138,7 +1135,7 @@ onUnmounted(() => {
   height: 320px;
 }
 
-.board-height-chart {
+.review-main-chart {
   height: 380px;
 }
 
@@ -1346,7 +1343,7 @@ onUnmounted(() => {
     height: 280px;
   }
 
-  .board-height-chart {
+  .review-main-chart {
     height: 340px;
   }
 

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -8,12 +8,7 @@
         </div>
 
         <div class="summary-controls">
-          <el-radio-group v-model="reviewMode" size="small">
-            <el-radio-button label="daily">收盘复盘</el-radio-button>
-            <el-radio-button label="intraday">盘中实时</el-radio-button>
-          </el-radio-group>
-
-          <el-radio-group v-if="reviewMode === 'daily'" v-model="timeRange" size="small">
+          <el-radio-group v-model="timeRange" size="small">
             <el-radio-button label="7">近7天</el-radio-button>
             <el-radio-button label="30">近30天</el-radio-button>
             <el-radio-button label="3m">近3月</el-radio-button>
@@ -22,14 +17,16 @@
       </div>
 
       <div class="summary-meta">
-        <span v-if="reviewMode === 'daily'">区间 {{ activeStartDate }} 至 {{ activeEndDate }}</span>
-        <span v-else>盘中快照 {{ activeEndDate }}</span>
+        <span>区间 {{ activeStartDate }} 至 {{ activeEndDate }}</span>
         <span>明细日期 {{ resolvedTradeDate }}</span>
-        <span v-if="reviewMode === 'intraday' && intradaySnapshotTime">
-          更新时间 {{ formatSnapshotTime(intradaySnapshotTime) }}
+        <span v-if="isLiveIntraday && intradaySnapshotTime">
+          实时更新 {{ formatSnapshotTime(intradaySnapshotTime) }}
         </span>
-        <el-tag v-if="reviewMode === 'intraday'" type="success" size="small">
-          盘中快照
+        <el-tag v-if="isLiveIntraday" type="success" size="small">
+          盘中实时
+        </el-tag>
+        <el-tag v-else type="info" size="small">
+          收盘复盘
         </el-tag>
         <el-tag v-if="hasFallback" type="warning" size="small">
           已回退到最近可用数据
@@ -266,7 +263,6 @@ import type {
 
 const router = useRouter()
 
-const reviewMode = ref<'daily' | 'intraday'>('daily')
 const timeRange = ref('30')
 const loading = ref(false)
 const activeStartDate = ref(dayjs().format('YYYY-MM-DD'))
@@ -277,6 +273,7 @@ const dailyRows = ref<MarketReviewDailyRow[]>([])
 const dailyHasFallback = ref(false)
 const detailResponse = ref<MarketReviewDetailResponse | null>(null)
 const ladderResponse = ref<MarketReviewLadderResponse | null>(null)
+const isLiveIntraday = ref(false)
 const intradaySnapshotTime = ref<string | null>(null)
 
 const boardHeightChartRef = ref<HTMLElement>()
@@ -293,7 +290,7 @@ let limitTrendChart: echarts.ECharts | null = null
 let breadthChart: echarts.ECharts | null = null
 let amountChart: echarts.ECharts | null = null
 let fetchSequence = 0
-let intradayRefreshTimer: number | null = null
+let reviewRefreshTimer: number | null = null
 
 const detailStocks = computed(() => detailResponse.value?.stocks ?? [])
 const ladderLevels = computed(() => ladderResponse.value?.ladders ?? [])
@@ -333,6 +330,28 @@ const strongestReason = computed(() => {
 
 function getDateRange() {
   return buildReviewRange(timeRange.value, dayjs().format('YYYY-MM-DD'))
+}
+
+function mergeIntradayDailyRows(
+  series: string[],
+  rows: MarketReviewDailyRow[],
+  intradayRow: MarketReviewDailyRow
+) {
+  const nextSeries = [...series]
+  const nextRows = [...rows]
+  const rowIndex = nextRows.findIndex(row => row.trade_date === intradayRow.trade_date)
+
+  if (rowIndex >= 0) {
+    nextRows[rowIndex] = intradayRow
+  } else {
+    nextSeries.push(intradayRow.trade_date)
+    nextRows.push(intradayRow)
+  }
+
+  return {
+    series: nextSeries,
+    rows: nextRows
+  }
 }
 
 function formatDateLabel(value: string) {
@@ -983,58 +1002,13 @@ async function fetchData() {
   const currentSequence = ++fetchSequence
   loading.value = true
   const today = dayjs().format('YYYY-MM-DD')
-
-  if (reviewMode.value === 'intraday') {
-    let hasError = false
-
-    try {
-      const dailyResult = await getMarketReviewIntraday(dayjs().format('YYYY-MM-DD'))
-
-      if (currentSequence !== fetchSequence) {
-        return
-      }
-
-      dailySeries.value = dailyResult.data.series
-      dailyRows.value = dailyResult.data.rows
-      dailyHasFallback.value = Boolean(dailyResult.is_fallback)
-      const snapshotDate = dailyResult.end_date || dailyResult.latest_trade_date || dailyResult.data.series[0] || today
-      activeStartDate.value = snapshotDate
-      activeEndDate.value = snapshotDate
-      intradaySnapshotTime.value = dailyResult.snapshot_time
-      detailResponse.value = dailyResult.detail
-      ladderResponse.value = dailyResult.ladder
-    } catch (e) {
-      console.error('Fetch market review intraday error:', e)
-      dailySeries.value = []
-      dailyRows.value = []
-      dailyHasFallback.value = false
-      detailResponse.value = null
-      ladderResponse.value = null
-      intradaySnapshotTime.value = null
-      activeStartDate.value = today
-      activeEndDate.value = today
-      hasError = true
-    }
-
-    if (currentSequence !== fetchSequence) {
-      return
-    }
-
-    updateCharts()
-
-    if (hasError) {
-      ElMessage.error('获取盘中复盘数据失败')
-    }
-
-    loading.value = false
-    return
-  }
-
   const { startDate, endDate, query } = getDateRange()
+  isLiveIntraday.value = false
   intradaySnapshotTime.value = null
 
   let detailDate = endDate
   let hasError = false
+  let hasLiveIntradayDetail = false
 
   try {
     const dailyResult = await getMarketReviewDaily(query)
@@ -1060,29 +1034,56 @@ async function fetchData() {
     hasError = true
   }
 
-  const [detailResult, ladderResult] = await Promise.allSettled([
-    getMarketReviewDetail(detailDate),
-    getMarketReviewLadder(detailDate)
-  ])
+  try {
+    const intradayResult = await getMarketReviewIntraday(today)
 
-  if (currentSequence !== fetchSequence) {
-    return
+    if (currentSequence !== fetchSequence) {
+      return
+    }
+
+    if (intradayResult.is_live && intradayResult.data.rows.length) {
+      const intradayRow = intradayResult.data.rows[0]
+      const mergedDaily = mergeIntradayDailyRows(dailySeries.value, dailyRows.value, intradayRow)
+      dailySeries.value = mergedDaily.series
+      dailyRows.value = mergedDaily.rows
+      dailyHasFallback.value = Boolean(dailyHasFallback.value || intradayResult.is_fallback)
+      activeEndDate.value = intradayRow.trade_date
+      detailDate = intradayRow.trade_date
+      isLiveIntraday.value = true
+      intradaySnapshotTime.value = intradayResult.snapshot_time
+      detailResponse.value = intradayResult.detail
+      ladderResponse.value = intradayResult.ladder
+      hasLiveIntradayDetail = true
+    }
+  } catch (e) {
+    console.warn('Fetch market review intraday status error:', e)
   }
 
-  if (detailResult.status === 'fulfilled') {
-    detailResponse.value = detailResult.value
-  } else {
-    console.error('Fetch market review detail error:', detailResult.reason)
-    detailResponse.value = null
-    hasError = true
-  }
+  if (!hasLiveIntradayDetail) {
+    const [detailResult, ladderResult] = await Promise.allSettled([
+      getMarketReviewDetail(detailDate),
+      getMarketReviewLadder(detailDate)
+    ])
 
-  if (ladderResult.status === 'fulfilled') {
-    ladderResponse.value = ladderResult.value
-  } else {
-    console.error('Fetch market review ladder error:', ladderResult.reason)
-    ladderResponse.value = null
-    hasError = true
+    if (currentSequence !== fetchSequence) {
+      return
+    }
+
+    if (detailResult.status === 'fulfilled') {
+      detailResponse.value = detailResult.value
+    } else {
+      console.error('Fetch market review detail error:', detailResult.reason)
+      detailResponse.value = null
+      hasError = true
+    }
+
+    if (ladderResult.status === 'fulfilled') {
+      ladderResponse.value = ladderResult.value
+    } else {
+      console.error('Fetch market review ladder error:', ladderResult.reason)
+      ladderResponse.value = null
+      hasError = true
+    }
   }
 
   updateCharts()
@@ -1104,42 +1105,30 @@ function handleRowClick(row: MarketReviewDetailStock) {
   goToDetail(row.stock_code)
 }
 
-watch(timeRange, () => {
-  if (reviewMode.value === 'daily') {
-    fetchData()
-  }
-})
+watch(timeRange, fetchData)
 
-function clearIntradayRefreshTimer() {
-  if (intradayRefreshTimer != null) {
-    window.clearInterval(intradayRefreshTimer)
-    intradayRefreshTimer = null
+function clearReviewRefreshTimer() {
+  if (reviewRefreshTimer != null) {
+    window.clearInterval(reviewRefreshTimer)
+    reviewRefreshTimer = null
   }
 }
 
-function resetIntradayRefreshTimer() {
-  clearIntradayRefreshTimer()
-  if (reviewMode.value === 'intraday') {
-    intradayRefreshTimer = window.setInterval(fetchData, 60000)
-  }
+function resetReviewRefreshTimer() {
+  clearReviewRefreshTimer()
+  reviewRefreshTimer = window.setInterval(fetchData, 60000)
 }
-
-watch(reviewMode, () => {
-  clearIntradayRefreshTimer()
-  fetchData()
-  resetIntradayRefreshTimer()
-})
 
 onMounted(() => {
   initCharts()
   updateCharts()
   fetchData()
-  resetIntradayRefreshTimer()
+  resetReviewRefreshTimer()
   window.addEventListener('resize', resizeCharts)
 })
 
 onUnmounted(() => {
-  clearIntradayRefreshTimer()
+  clearReviewRefreshTimer()
   window.removeEventListener('resize', resizeCharts)
   disposeCharts()
 })

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -32,7 +32,7 @@
               <p>龙头高度、次高板高度与创业板高度。</p>
             </div>
           </div>
-          <div ref="boardHeightChartRef" class="chart-container"></div>
+          <div ref="boardHeightChartRef" class="chart-container board-height-chart"></div>
         </div>
       </el-col>
       <el-col :xs="24" :lg="12">
@@ -115,6 +115,21 @@
                   {{ ladder.continuous_days }}连板
                 </span>
                 <span class="count">{{ ladder.count }}只</span>
+              </div>
+
+              <div class="ladder-metrics">
+                <span class="metric-pill metric-sealed">
+                  封板 <strong>{{ getSealedCount(ladder) }}</strong>
+                </span>
+                <span class="metric-pill metric-opened">
+                  炸板 <strong>{{ getOpenedCount(ladder) }}</strong>
+                </span>
+                <span class="metric-pill metric-rate">
+                  封板率 <strong>{{ getLadderSealRate(ladder) }}</strong>
+                </span>
+                <span class="metric-pill metric-average" :class="getChangeClass(getLadderAverageChangeValue(ladder))">
+                  均涨 <strong>{{ getLadderAverageChange(ladder) }}</strong>
+                </span>
               </div>
 
               <div class="stock-chip-list">
@@ -231,6 +246,7 @@ import type {
   MarketReviewDailyRow,
   MarketReviewDetailResponse,
   MarketReviewDetailStock,
+  MarketReviewLadderLevel,
   MarketReviewLadderResponse
 } from '@/types/market'
 
@@ -351,6 +367,37 @@ function getStockStatusLabel(stock: MarketReviewDetailStock) {
   return '观察'
 }
 
+function getSealedCount(ladder: MarketReviewLadderLevel) {
+  return ladder.stocks.filter(stock => stock.today_sealed_close).length
+}
+
+function getOpenedCount(ladder: MarketReviewLadderLevel) {
+  return ladder.stocks.filter(stock => stock.today_opened_close).length
+}
+
+function getLadderSealRate(ladder: MarketReviewLadderLevel) {
+  const total = ladder.count || ladder.stocks.length
+  if (!total) {
+    return '0.00%'
+  }
+  return `${((getSealedCount(ladder) / total) * 100).toFixed(2)}%`
+}
+
+function getLadderAverageChangeValue(ladder: MarketReviewLadderLevel) {
+  const changes = ladder.stocks
+    .map(stock => stock.change_pct)
+    .filter((value): value is number => value != null)
+
+  if (!changes.length) {
+    return null
+  }
+  return changes.reduce((sum, value) => sum + value, 0) / changes.length
+}
+
+function getLadderAverageChange(ladder: MarketReviewLadderLevel) {
+  return formatPercent(getLadderAverageChangeValue(ladder))
+}
+
 function createEmptyOption(): echarts.EChartsOption {
   return {
     graphic: {
@@ -410,7 +457,6 @@ function getBaseGridOption(boundaryGap = false): Pick<echarts.EChartsOption, 'gr
 type BoardLabelField = 'max_board_label' | 'second_board_label' | 'gem_board_label'
 type BoardHeightField = 'max_board_height' | 'second_board_height' | 'gem_board_height'
 
-const boardLabelFields: BoardLabelField[] = ['max_board_label', 'second_board_label', 'gem_board_label']
 const boardHeightFieldMap: Record<BoardLabelField, BoardHeightField> = {
   max_board_label: 'max_board_height',
   second_board_label: 'second_board_height',
@@ -429,26 +475,7 @@ function getBoardHeight(row: MarketReviewDailyRow | undefined, field: BoardLabel
   return Number(row?.[boardHeightFieldMap[field]] || 0)
 }
 
-function isDominantBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
-  const row = dailyRows.value[rowIndex]
-  if (!row) {
-    return false
-  }
-
-  const currentHeight = getBoardHeight(row, field)
-  const currentOrder = boardLabelFields.indexOf(field)
-
-  return boardLabelFields.every((candidate, candidateOrder) => {
-    if (candidate === field || !row[candidate]) {
-      return true
-    }
-
-    const candidateHeight = getBoardHeight(row, candidate)
-    return currentHeight > candidateHeight || (currentHeight === candidateHeight && currentOrder < candidateOrder)
-  })
-}
-
-function isSparseBoardHeightLabelPoint(rowIndex: number, field: BoardLabelField) {
+function isBoardHeightLabelPoint(rowIndex: number, field: BoardLabelField) {
   const row = dailyRows.value[rowIndex]
   const currentHeight = getBoardHeight(row, field)
   if (currentHeight < 2) {
@@ -457,13 +484,14 @@ function isSparseBoardHeightLabelPoint(rowIndex: number, field: BoardLabelField)
 
   const prevHeight = getBoardHeight(dailyRows.value[rowIndex - 1], field)
   const nextHeight = getBoardHeight(dailyRows.value[rowIndex + 1], field)
+  const isFirstPoint = rowIndex === 0
   const isLastPoint = rowIndex === dailyRows.value.length - 1
-  const isStrictPeak = currentHeight > prevHeight && currentHeight > nextHeight
+  const isLocalPeak = currentHeight >= prevHeight && currentHeight >= nextHeight && (
+    currentHeight > prevHeight || currentHeight > nextHeight
+  )
+  const isChangedPoint = currentHeight !== prevHeight || currentHeight !== nextHeight
 
-  if (isLastPoint) {
-    return field === 'max_board_label' && currentHeight >= 3
-  }
-  return isStrictPeak && currentHeight >= (field === 'max_board_label' ? 4 : 3)
+  return isFirstPoint || isLastPoint || isLocalPeak || isChangedPoint
 }
 
 function shouldShowBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
@@ -471,10 +499,7 @@ function shouldShowBoardHeightLabel(rowIndex: number, field: BoardLabelField) {
   if (!row?.[field]) {
     return false
   }
-  if (!isDominantBoardHeightLabel(rowIndex, field)) {
-    return false
-  }
-  return isSparseBoardHeightLabelPoint(rowIndex, field)
+  return isBoardHeightLabelPoint(rowIndex, field)
 }
 
 function getBoardLabelFormatter(field: BoardLabelField) {
@@ -487,17 +512,25 @@ function getBoardLabelFormatter(field: BoardLabelField) {
   }
 }
 
-function getBoardHeightLabelOption(field: BoardLabelField, position: 'top' | 'bottom' = 'top') {
+function getBoardHeightLabelOption(
+  field: BoardLabelField,
+  position: 'top' | 'bottom' = 'top',
+  offset: [number, number] = [0, 0]
+) {
   return {
     show: true,
     position,
+    offset,
     formatter: getBoardLabelFormatter(field),
     color: '#262626',
-    fontSize: 12,
-    lineHeight: 16,
-    distance: 8,
-    width: 110,
-    overflow: 'truncate'
+    fontSize: 11,
+    lineHeight: 14,
+    distance: 6,
+    width: 100,
+    overflow: 'truncate',
+    backgroundColor: 'rgba(255, 255, 255, 0.86)',
+    borderRadius: 4,
+    padding: [2, 4]
   }
 }
 
@@ -544,6 +577,12 @@ function updateCharts() {
   boardHeightChart?.setOption(
     {
       ...getBaseGridOption(),
+      grid: {
+        left: 56,
+        right: 28,
+        top: 80,
+        bottom: 46
+      },
       tooltip: {
         trigger: 'axis',
         formatter: formatBoardHeightTooltip
@@ -563,7 +602,7 @@ function updateCharts() {
           labelLayout: {
             hideOverlap: true
           },
-          label: getBoardHeightLabelOption('max_board_label')
+          label: getBoardHeightLabelOption('max_board_label', 'top', [0, -6])
         },
         {
           name: '次高板高度',
@@ -575,7 +614,7 @@ function updateCharts() {
           labelLayout: {
             hideOverlap: true
           },
-          label: getBoardHeightLabelOption('second_board_label')
+          label: getBoardHeightLabelOption('second_board_label', 'bottom', [0, 16])
         },
         {
           name: '创业板高度',
@@ -587,7 +626,7 @@ function updateCharts() {
           labelLayout: {
             hideOverlap: true
           },
-          label: getBoardHeightLabelOption('gem_board_label', 'bottom')
+          label: getBoardHeightLabelOption('gem_board_label', 'bottom', [0, 28])
         }
       ]
     },
@@ -997,6 +1036,10 @@ onUnmounted(() => {
   height: 320px;
 }
 
+.board-height-chart {
+  height: 380px;
+}
+
 .detail-summary {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -1069,6 +1112,57 @@ onUnmounted(() => {
   color: #595959;
   font-size: 13px;
   font-weight: 500;
+}
+
+.ladder-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.metric-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+  border-radius: 6px;
+  background: #fff;
+  padding: 5px 6px;
+  color: #595959;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+
+  strong {
+    color: inherit;
+    font-weight: 600;
+  }
+
+  &.metric-sealed {
+    color: #f5222d;
+  }
+
+  &.metric-opened {
+    color: #fa8c16;
+  }
+
+  &.metric-rate {
+    color: #1677ff;
+  }
+}
+
+.metric-average.positive {
+  color: #f5222d;
+}
+
+.metric-average.negative {
+  color: #52c41a;
+}
+
+.metric-average.neutral {
+  color: #8c8c8c;
 }
 
 .stock-chip-list {
@@ -1148,6 +1242,14 @@ onUnmounted(() => {
 
   .chart-container {
     height: 280px;
+  }
+
+  .board-height-chart {
+    height: 340px;
+  }
+
+  .ladder-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .detail-summary {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -351,6 +351,13 @@ function formatPercent(value: number | null | undefined) {
   return `${sign}${value.toFixed(2)}%`
 }
 
+function formatRate(value: number | null | undefined) {
+  if (value == null) {
+    return '-'
+  }
+  return `${value.toFixed(2)}%`
+}
+
 function formatPercentAxisLabel(value: number | string | null | undefined) {
   const numericValue = Number(value)
   if (!Number.isFinite(numericValue)) {
@@ -429,22 +436,11 @@ function getOpenedCount(ladder: MarketReviewLadderLevel) {
 }
 
 function getLadderSealRate(ladder: MarketReviewLadderLevel) {
-  const total = ladder.count || ladder.stocks.length
-  if (!total) {
-    return '0.00%'
-  }
-  return `${((getSealedCount(ladder) / total) * 100).toFixed(2)}%`
+  return formatRate(ladder.cohort_seal_rate)
 }
 
 function getLadderAverageChangeValue(ladder: MarketReviewLadderLevel) {
-  const changes = ladder.stocks
-    .map(stock => stock.change_pct)
-    .filter((value): value is number => value != null)
-
-  if (!changes.length) {
-    return null
-  }
-  return changes.reduce((sum, value) => sum + value, 0) / changes.length
+  return ladder.cohort_avg_change
 }
 
 function getLadderAverageChange(ladder: MarketReviewLadderLevel) {

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -330,6 +330,23 @@ function formatPercent(value: number | null | undefined) {
   return `${sign}${value.toFixed(2)}%`
 }
 
+function formatPercentAxisLabel(value: number | string | null | undefined) {
+  const numericValue = Number(value)
+  if (!Number.isFinite(numericValue)) {
+    return '-'
+  }
+  return `${numericValue.toFixed(0)}%`
+}
+
+function formatPercentPointLabel(value: number | string | null | undefined, signed = false) {
+  const numericValue = Number(value)
+  if (!Number.isFinite(numericValue)) {
+    return '-'
+  }
+  const sign = signed && numericValue > 0 ? '+' : ''
+  return `${sign}${numericValue.toFixed(1)}%`
+}
+
 function formatAmount(value: number) {
   if (Math.abs(value) >= 100000000) {
     return `${(value / 100000000).toFixed(2)}亿`
@@ -338,6 +355,21 @@ function formatAmount(value: number) {
     return `${(value / 10000).toFixed(2)}万`
   }
   return value.toFixed(0)
+}
+
+function toYiAmount(value: number | null | undefined) {
+  if (value == null) {
+    return 0
+  }
+  return Number((value / 100000000).toFixed(2))
+}
+
+function formatYiAmount(value: number | string | null | undefined) {
+  const numericValue = Number(value)
+  if (!Number.isFinite(numericValue)) {
+    return '-'
+  }
+  return `${numericValue.toFixed(2)}亿`
 }
 
 function getChangeClass(value: number | null | undefined) {
@@ -534,6 +566,32 @@ function getBoardHeightLabelOption(
   }
 }
 
+function getPercentPointLabelOption(position: 'top' | 'bottom' = 'top', signed = false) {
+  return {
+    show: true,
+    position,
+    formatter: (params: { value?: number | string }) => formatPercentPointLabel(params.value, signed),
+    color: '#262626',
+    fontSize: 11,
+    lineHeight: 14,
+    distance: 6,
+    backgroundColor: 'rgba(255, 255, 255, 0.86)',
+    borderRadius: 4,
+    padding: [2, 4]
+  }
+}
+
+function getYiAmountLabelOption() {
+  return {
+    show: true,
+    position: 'top',
+    formatter: (params: { value?: number | string }) => formatYiAmount(Number(params.value)),
+    color: '#595959',
+    fontSize: 11,
+    distance: 4
+  }
+}
+
 function formatBoardHeightTooltip(params: unknown) {
   const items = Array.isArray(params) ? params : [params]
   const dataIndex = Number((items[0] as { dataIndex?: number } | undefined)?.dataIndex ?? -1)
@@ -638,8 +696,10 @@ function updateCharts() {
       ...getBaseGridOption(),
       yAxis: {
         type: 'value',
+        min: 0,
+        max: 100,
         axisLabel: {
-          formatter: '{value}%'
+          formatter: (value: number) => formatPercentAxisLabel(value)
         }
       },
       series: [
@@ -649,6 +709,10 @@ function updateCharts() {
           smooth: true,
           data: dailyRows.value.map(row => row.first_to_second_rate),
           itemStyle: { color: '#f5222d' },
+          labelLayout: {
+            hideOverlap: true
+          },
+          label: getPercentPointLabelOption('top'),
           areaStyle: {
             color: 'rgba(245, 34, 45, 0.08)'
           }
@@ -659,6 +723,10 @@ function updateCharts() {
           smooth: true,
           data: dailyRows.value.map(row => row.continuous_promotion_rate),
           itemStyle: { color: '#722ed1' },
+          labelLayout: {
+            hideOverlap: true
+          },
+          label: getPercentPointLabelOption('bottom'),
           areaStyle: {
             color: 'rgba(114, 46, 209, 0.08)'
           }
@@ -668,7 +736,11 @@ function updateCharts() {
           type: 'line',
           smooth: true,
           data: dailyRows.value.map(row => row.seal_rate),
-          itemStyle: { color: '#13c2c2' }
+          itemStyle: { color: '#13c2c2' },
+          labelLayout: {
+            hideOverlap: true
+          },
+          label: getPercentPointLabelOption('top')
         }
       ]
     },
@@ -681,7 +753,7 @@ function updateCharts() {
       yAxis: {
         type: 'value',
         axisLabel: {
-          formatter: '{value}%'
+          formatter: (value: number) => formatPercentAxisLabel(value)
         }
       },
       series: [
@@ -691,7 +763,26 @@ function updateCharts() {
           smooth: false,
           symbol: 'circle',
           data: dailyRows.value.map(row => row.yesterday_limit_up_avg_change),
-          itemStyle: { color: '#ff7875' }
+          itemStyle: { color: '#ff7875' },
+          labelLayout: {
+            hideOverlap: true
+          },
+          label: getPercentPointLabelOption('top', true),
+          markLine: {
+            symbol: 'none',
+            silent: true,
+            label: {
+              formatter: '0%',
+              color: '#8c8c8c'
+            },
+            lineStyle: {
+              color: '#8c8c8c',
+              type: 'dashed'
+            },
+            data: [
+              { yAxis: 0 }
+            ]
+          }
         },
         {
           name: '昨日连板平均涨幅',
@@ -699,7 +790,11 @@ function updateCharts() {
           smooth: false,
           symbol: 'circle',
           data: dailyRows.value.map(row => row.yesterday_continuous_avg_change),
-          itemStyle: { color: '#52c41a' }
+          itemStyle: { color: '#52c41a' },
+          labelLayout: {
+            hideOverlap: true
+          },
+          label: getPercentPointLabelOption('bottom', true)
         }
       ]
     },
@@ -790,25 +885,32 @@ function updateCharts() {
   amountChart?.setOption(
     {
       ...getBaseGridOption(true),
+      tooltip: {
+        trigger: 'axis',
+        valueFormatter: (value: unknown) => formatYiAmount(Number(value))
+      },
       yAxis: {
         type: 'value',
+        name: '亿元',
         axisLabel: {
-          formatter: (value: number) => formatAmount(value)
+          formatter: (value: number) => formatYiAmount(value)
         }
       },
       series: [
         {
           name: '涨停成交额',
           type: 'bar',
-          data: dailyRows.value.map(row => row.limit_up_amount),
+          data: dailyRows.value.map(row => toYiAmount(row.limit_up_amount)),
           itemStyle: { color: '#f5222d' },
+          label: getYiAmountLabelOption(),
           barMaxWidth: 26
         },
         {
           name: '炸板成交额',
           type: 'bar',
-          data: dailyRows.value.map(row => row.broken_amount),
+          data: dailyRows.value.map(row => toYiAmount(row.broken_amount)),
           itemStyle: { color: '#faad14' },
+          label: getYiAmountLabelOption(),
           barMaxWidth: 26
         }
       ]

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -83,7 +83,7 @@ async function fetchData() {
     updateTrendChart(dailyStats)
     updatePieChart(dailyStats[0])
     updateBreakChart(dailyStats)
-    updateSectorChart(sectorStats)
+    updateSectorChart(sectorStats.data)
   } catch (e) {
     console.error('Fetch stats error:', e)
   }

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -357,11 +357,11 @@ function formatAmount(value: number) {
   return value.toFixed(0)
 }
 
-function toYiAmount(value: number | null | undefined) {
+function toYiFromWanAmount(value: number | null | undefined) {
   if (value == null) {
     return 0
   }
-  return Number((value / 100000000).toFixed(2))
+  return Number((value / 10000).toFixed(2))
 }
 
 function formatYiAmount(value: number | string | null | undefined) {
@@ -897,7 +897,7 @@ function updateCharts() {
         {
           name: '涨停成交额',
           type: 'bar',
-          data: dailyRows.value.map(row => toYiAmount(row.limit_up_amount)),
+          data: dailyRows.value.map(row => toYiFromWanAmount(row.limit_up_amount)),
           itemStyle: { color: '#f5222d' },
           label: getYiAmountLabelOption(),
           barMaxWidth: 26
@@ -905,7 +905,7 @@ function updateCharts() {
         {
           name: '炸板成交额',
           type: 'bar',
-          data: dailyRows.value.map(row => toYiAmount(row.broken_amount)),
+          data: dailyRows.value.map(row => toYiFromWanAmount(row.broken_amount)),
           itemStyle: { color: '#faad14' },
           label: getYiAmountLabelOption(),
           barMaxWidth: 26

--- a/frontend/src/views/Statistics.vue
+++ b/frontend/src/views/Statistics.vue
@@ -998,13 +998,25 @@ function disposeCharts() {
   amountChart = null
 }
 
-async function fetchData() {
+type FetchDataOptions = {
+  silent?: boolean
+}
+
+async function fetchData(options: FetchDataOptions = {}) {
   const currentSequence = ++fetchSequence
-  loading.value = true
+  const shouldShowLoading = !options.silent
+
+  if (shouldShowLoading) {
+    loading.value = true
+  }
+
   const today = dayjs().format('YYYY-MM-DD')
   const { startDate, endDate, query } = getDateRange()
-  isLiveIntraday.value = false
-  intradaySnapshotTime.value = null
+
+  if (shouldShowLoading) {
+    isLiveIntraday.value = false
+    intradaySnapshotTime.value = null
+  }
 
   let detailDate = endDate
   let hasError = false
@@ -1026,6 +1038,9 @@ async function fetchData() {
     detailDate = activeEndDate.value
   } catch (e) {
     console.error('Fetch market review daily error:', e)
+    if (options.silent) {
+      return
+    }
     dailySeries.value = []
     dailyRows.value = []
     dailyHasFallback.value = false
@@ -1054,6 +1069,9 @@ async function fetchData() {
       detailResponse.value = intradayResult.detail
       ladderResponse.value = intradayResult.ladder
       hasLiveIntradayDetail = true
+    } else {
+      isLiveIntraday.value = false
+      intradaySnapshotTime.value = null
     }
   } catch (e) {
     console.warn('Fetch market review intraday status error:', e)
@@ -1073,26 +1091,30 @@ async function fetchData() {
       detailResponse.value = detailResult.value
     } else {
       console.error('Fetch market review detail error:', detailResult.reason)
-      detailResponse.value = null
-      hasError = true
+      if (!options.silent) {
+        detailResponse.value = null
+        hasError = true
+      }
     }
 
     if (ladderResult.status === 'fulfilled') {
       ladderResponse.value = ladderResult.value
     } else {
       console.error('Fetch market review ladder error:', ladderResult.reason)
-      ladderResponse.value = null
-      hasError = true
+      if (!options.silent) {
+        ladderResponse.value = null
+        hasError = true
+      }
     }
   }
 
   updateCharts()
 
-  if (hasError) {
+  if (hasError && shouldShowLoading) {
     ElMessage.error('获取市场复盘数据失败')
   }
 
-  if (currentSequence === fetchSequence) {
+  if (shouldShowLoading && currentSequence === fetchSequence) {
     loading.value = false
   }
 }
@@ -1105,7 +1127,7 @@ function handleRowClick(row: MarketReviewDetailStock) {
   goToDetail(row.stock_code)
 }
 
-watch(timeRange, fetchData)
+watch(timeRange, () => fetchData())
 
 function clearReviewRefreshTimer() {
   if (reviewRefreshTimer != null) {
@@ -1114,9 +1136,16 @@ function clearReviewRefreshTimer() {
   }
 }
 
+function refreshReviewSilently() {
+  if (loading.value) {
+    return
+  }
+  void fetchData({ silent: true })
+}
+
 function resetReviewRefreshTimer() {
   clearReviewRefreshTimer()
-  reviewRefreshTimer = window.setInterval(fetchData, 60000)
+  reviewRefreshTimer = window.setInterval(refreshReviewSilently, 60000)
 }
 
 onMounted(() => {

--- a/frontend/src/views/StockDetail.vue
+++ b/frontend/src/views/StockDetail.vue
@@ -5,7 +5,7 @@
       <div class="basic-info">
         <h2>{{ stockInfo.stock_name }} <span class="code">{{ stockCode }}</span></h2>
         <div class="tags">
-          <el-tag v-if="stockInfo.continuous_limit_up_days > 1" type="info" size="small">
+          <el-tag v-if="(stockInfo.continuous_limit_up_days || 0) > 1" type="info" size="small">
             {{ stockInfo.continuous_limit_up_days }}连板
           </el-tag>
           <el-tag :type="stockInfo.is_final_sealed ? 'info' : 'warning'" size="small">
@@ -35,7 +35,7 @@
           <span class="highlight-value">{{ stockInfo.final_seal_time || '-' }}</span>
         </el-descriptions-item>
         <el-descriptions-item label="连板天数">
-          <el-tag v-if="stockInfo.continuous_limit_up_days > 1" type="danger" size="small">
+          <el-tag v-if="(stockInfo.continuous_limit_up_days || 0) > 1" type="danger" size="small">
             {{ stockInfo.continuous_limit_up_days }}板
           </el-tag>
           <span v-else>首板</span>

--- a/frontend/src/views/StockDetail.vue
+++ b/frontend/src/views/StockDetail.vue
@@ -5,7 +5,7 @@
       <div class="basic-info">
         <h2>{{ stockInfo.stock_name }} <span class="code">{{ stockCode }}</span></h2>
         <div class="tags">
-          <el-tag v-if="stockInfo.continuous_limit_up_days > 1" type="info" size="small">
+          <el-tag v-if="(stockInfo.continuous_limit_up_days || 1) > 1" type="info" size="small">
             {{ stockInfo.continuous_limit_up_days }}连板
           </el-tag>
           <el-tag :type="stockInfo.is_final_sealed ? 'info' : 'warning'" size="small">
@@ -35,7 +35,7 @@
           <span class="highlight-value">{{ stockInfo.final_seal_time || '-' }}</span>
         </el-descriptions-item>
         <el-descriptions-item label="连板天数">
-          <el-tag v-if="stockInfo.continuous_limit_up_days > 1" type="danger" size="small">
+          <el-tag v-if="(stockInfo.continuous_limit_up_days || 1) > 1" type="danger" size="small">
             {{ stockInfo.continuous_limit_up_days }}板
           </el-tag>
           <span v-else>首板</span>

--- a/frontend/tests/reviewRange.test.mjs
+++ b/frontend/tests/reviewRange.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildReviewRange } from '../.tmp-review-range/reviewRange.js'
+
+test('builds trading-session query for every quick review range', () => {
+  const today = '2026-04-30'
+
+  for (const [range, days] of [
+    ['7', 7],
+    ['30', 30],
+    ['90', 90]
+  ]) {
+    const result = buildReviewRange(range, today)
+
+    assert.equal(result.endDate, today)
+    assert.equal(result.startDate, today)
+    assert.deepEqual(result.query, {
+      days,
+      end_date: today
+    })
+  }
+})

--- a/frontend/tests/reviewRange.test.mjs
+++ b/frontend/tests/reviewRange.test.mjs
@@ -8,7 +8,7 @@ test('builds trading-session query for every quick review range', () => {
   for (const [range, days] of [
     ['7', 7],
     ['30', 30],
-    ['90', 90]
+    ['3m', 60]
   ]) {
     const result = buildReviewRange(range, today)
 

--- a/frontend/tests/run-review-range-test.mjs
+++ b/frontend/tests/run-review-range-test.mjs
@@ -1,0 +1,32 @@
+import { execFileSync } from 'node:child_process'
+import { rmSync } from 'node:fs'
+
+const tempDir = '.tmp-review-range'
+const tscEntry = 'node_modules/typescript/bin/tsc'
+
+try {
+  rmSync(tempDir, { recursive: true, force: true })
+  execFileSync(process.execPath, [
+    tscEntry,
+    'src/utils/reviewRange.ts',
+    '--target',
+    'ES2020',
+    '--module',
+    'ESNext',
+    '--moduleResolution',
+    'bundler',
+    '--outDir',
+    tempDir,
+    '--noEmit',
+    'false',
+    '--declaration',
+    'false',
+    '--skipLibCheck',
+    'true',
+    '--strict',
+    'true'
+  ], { stdio: 'inherit' })
+  execFileSync(process.execPath, ['--test', 'tests/reviewRange.test.mjs'], { stdio: 'inherit' })
+} finally {
+  rmSync(tempDir, { recursive: true, force: true })
+}

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -17,6 +17,14 @@ test('board height chart displays stock labels from daily rows', () => {
   assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom'\)/)
 })
 
+test('board height labels cap crowded points', () => {
+  assert.match(source, /function isDominantBoardHeightLabel/, 'only one board label should be eligible per date')
+  assert.match(source, /function isSparseBoardHeightLabelPoint/, 'non-peak labels should be suppressed')
+  assert.match(source, /!isDominantBoardHeightLabel\(rowIndex, field\)/)
+  assert.match(source, /labelLayout:\s*\{\s*hideOverlap: true/s)
+  assert.match(source, /return `\$\{lines\[0\]\} 等\$\{lines\.length\}只`/)
+})
+
 test('yesterday feedback chart uses straight line series', () => {
   const match = source.match(/yesterdayChangeChart\?\.setOption\([\s\S]*?limitTrendChart\?\.setOption/)
   assert.ok(match, 'yesterday feedback chart option should exist')
@@ -28,9 +36,16 @@ test('yesterday feedback chart uses straight line series', () => {
   assert.doesNotMatch(optionSource, /type: 'bar'/, 'yesterday feedback chart should not use bars')
 })
 
-test('ladder groups show seal rate and average change', () => {
-  assert.match(source, /封板率\s*\{\{\s*getLadderSealRate\(ladder\)\s*\}\}/)
-  assert.match(source, /均涨\s*\{\{\s*getLadderAverageChange\(ladder\)\s*\}\}/)
-  assert.match(source, /function getLadderSealRate\(ladder: MarketReviewLadderLevel\)/)
-  assert.match(source, /function getLadderAverageChange\(ladder: MarketReviewLadderLevel\)/)
+test('ladder groups avoid redundant sealed-only stats', () => {
+  const match = source.match(/<div class="ladder-header">[\s\S]*?<\/div>/)
+  assert.ok(match, 'ladder header should exist')
+  const headerSource = match[0]
+
+  assert.match(headerSource, /\{\{\s*ladder\.count\s*\}\}只/)
+  assert.doesNotMatch(headerSource, /封板|炸板|封板率|均涨/)
+  assert.doesNotMatch(headerSource, /getSealedCount|getOpenedCount|getLadderSealRate|getLadderAverageChange/)
+  assert.doesNotMatch(source, /function getSealedCount/)
+  assert.doesNotMatch(source, /function getOpenedCount/)
+  assert.doesNotMatch(source, /function getLadderSealRate/)
+  assert.doesNotMatch(source, /function getLadderAverageChange/)
 })

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -93,3 +93,12 @@ test('ladder groups show stats in a separate compact metrics row', () => {
   assert.match(source, /function getLadderAverageChange\(ladder: MarketReviewLadderLevel\)/)
   assert.match(source, /\.ladder-metrics\s*\{[\s\S]*grid-template-columns: repeat\(4, minmax\(0, 1fr\)\)/)
 })
+
+test('ladder seal rate and average change use same-cohort metrics from backend', () => {
+  const typeSource = readFileSync('src/types/market.ts', 'utf8')
+  assert.match(typeSource, /cohort_count:\s*number/)
+  assert.match(typeSource, /cohort_seal_rate:\s*number/)
+  assert.match(typeSource, /cohort_avg_change:\s*number \| null/)
+  assert.match(source, /return formatRate\(ladder\.cohort_seal_rate\)/)
+  assert.match(source, /return ladder\.cohort_avg_change/)
+})

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const source = readFileSync('src/views/Statistics.vue', 'utf8')
+
+test('board height chart displays stock labels from daily rows', () => {
+  assert.match(source, /max_board_label/, 'max board labels should be used in the chart')
+  assert.match(source, /second_board_label/, 'second board labels should be used in the chart')
+  assert.match(source, /gem_board_label/, 'GEM board labels should be used in the chart')
+  assert.match(source, /function getBoardLabelFormatter/, 'chart point labels should have a formatter')
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('max_board_label'\)/)
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('second_board_label'\)/)
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom'\)/)
+})

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -12,16 +12,18 @@ test('board height chart displays stock labels from daily rows', () => {
   assert.match(source, /function shouldShowBoardHeightLabel/, 'labels should be filtered to avoid crowding')
   assert.match(source, /function formatBoardHeightTooltip/, 'full labels should remain available in tooltip')
   assert.match(source, /tooltip:\s*\{\s*trigger: 'axis',\s*formatter: formatBoardHeightTooltip/s)
-  assert.match(source, /label:\s*getBoardHeightLabelOption\('max_board_label'\)/)
-  assert.match(source, /label:\s*getBoardHeightLabelOption\('second_board_label'\)/)
-  assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom'\)/)
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('max_board_label', 'top', \[0, -6\]\)/)
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('second_board_label', 'bottom', \[0, 16\]\)/)
+  assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom', \[0, 28\]\)/)
 })
 
-test('board height labels cap crowded points', () => {
-  assert.match(source, /function isDominantBoardHeightLabel/, 'only one board label should be eligible per date')
-  assert.match(source, /function isSparseBoardHeightLabelPoint/, 'non-peak labels should be suppressed')
-  assert.match(source, /!isDominantBoardHeightLabel\(rowIndex, field\)/)
+test('board height labels keep more data with layout controls', () => {
+  assert.match(source, /class="chart-container board-height-chart"/, 'board chart should have more vertical space')
+  assert.match(source, /function isBoardHeightLabelPoint/, 'changed height points should be eligible for labels')
+  assert.match(source, /currentHeight !== prevHeight \|\| currentHeight !== nextHeight/)
   assert.match(source, /labelLayout:\s*\{\s*hideOverlap: true/s)
+  assert.match(source, /getBoardHeightLabelOption\('max_board_label', 'top', \[0, -6\]\)/)
+  assert.match(source, /getBoardHeightLabelOption\('second_board_label', 'bottom', \[0, 16\]\)/)
   assert.match(source, /return `\$\{lines\[0\]\} 等\$\{lines\.length\}只`/)
 })
 
@@ -36,16 +38,16 @@ test('yesterday feedback chart uses straight line series', () => {
   assert.doesNotMatch(optionSource, /type: 'bar'/, 'yesterday feedback chart should not use bars')
 })
 
-test('ladder groups avoid redundant sealed-only stats', () => {
-  const match = source.match(/<div class="ladder-header">[\s\S]*?<\/div>/)
-  assert.ok(match, 'ladder header should exist')
-  const headerSource = match[0]
+test('ladder groups show stats in a separate compact metrics row', () => {
+  const match = source.match(/<div class="ladder-metrics">[\s\S]*?<\/div>/)
+  assert.ok(match, 'ladder metrics row should exist')
+  const metricsSource = match[0]
 
-  assert.match(headerSource, /\{\{\s*ladder\.count\s*\}\}只/)
-  assert.doesNotMatch(headerSource, /封板|炸板|封板率|均涨/)
-  assert.doesNotMatch(headerSource, /getSealedCount|getOpenedCount|getLadderSealRate|getLadderAverageChange/)
-  assert.doesNotMatch(source, /function getSealedCount/)
-  assert.doesNotMatch(source, /function getOpenedCount/)
-  assert.doesNotMatch(source, /function getLadderSealRate/)
-  assert.doesNotMatch(source, /function getLadderAverageChange/)
+  assert.match(metricsSource, /封板[\s\S]*getSealedCount\(ladder\)/)
+  assert.match(metricsSource, /炸板[\s\S]*getOpenedCount\(ladder\)/)
+  assert.match(metricsSource, /封板率[\s\S]*getLadderSealRate\(ladder\)/)
+  assert.match(metricsSource, /均涨[\s\S]*getLadderAverageChange\(ladder\)/)
+  assert.match(source, /function getLadderSealRate\(ladder: MarketReviewLadderLevel\)/)
+  assert.match(source, /function getLadderAverageChange\(ladder: MarketReviewLadderLevel\)/)
+  assert.match(source, /\.ladder-metrics\s*\{[\s\S]*grid-template-columns: repeat\(4, minmax\(0, 1fr\)\)/)
 })

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -13,3 +13,14 @@ test('board height chart displays stock labels from daily rows', () => {
   assert.match(source, /label:\s*getBoardHeightLabelOption\('second_board_label'\)/)
   assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom'\)/)
 })
+
+test('yesterday feedback chart uses straight line series', () => {
+  const match = source.match(/yesterdayChangeChart\?\.setOption\([\s\S]*?limitTrendChart\?\.setOption/)
+  assert.ok(match, 'yesterday feedback chart option should exist')
+  const optionSource = match[0]
+
+  assert.match(optionSource, /name: '昨日涨停平均涨幅'[\s\S]*?type: 'line'/)
+  assert.match(optionSource, /name: '昨日连板平均涨幅'[\s\S]*?type: 'line'/)
+  assert.doesNotMatch(optionSource, /smooth: true/, 'yesterday feedback lines should not be smoothed')
+  assert.doesNotMatch(optionSource, /type: 'bar'/, 'yesterday feedback chart should not use bars')
+})

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -18,13 +18,19 @@ test('board height chart displays stock labels from daily rows', () => {
 })
 
 test('board height labels keep more data with layout controls', () => {
-  assert.match(source, /class="chart-container board-height-chart"/, 'board chart should have more vertical space')
+  assert.match(source, /ref="boardHeightChartRef" class="chart-container review-main-chart"/)
+  assert.match(source, /ref="promotionRateChartRef" class="chart-container review-main-chart"/)
   assert.match(source, /function isBoardHeightLabelPoint/, 'changed height points should be eligible for labels')
   assert.match(source, /currentHeight !== prevHeight \|\| currentHeight !== nextHeight/)
   assert.match(source, /labelLayout:\s*\{\s*hideOverlap: true/s)
   assert.match(source, /getBoardHeightLabelOption\('max_board_label', 'top', \[0, -6\]\)/)
   assert.match(source, /getBoardHeightLabelOption\('second_board_label', 'bottom', \[0, 16\]\)/)
-  assert.match(source, /return `\$\{lines\[0\]\} 等\$\{lines\.length\}只`/)
+  assert.match(source, /if \(lines\.length <= 3\) \{[\s\S]*return lines\.join\('\\n'\)/)
+  assert.match(source, /return `\$\{lines\.slice\(0, 3\)\.join\('\\n'\)\}\\n等\$\{lines\.length\}只`/)
+  assert.match(source, /\.review-main-chart\s*\{[\s\S]*height: 380px/)
+  const boardLabelOption = source.match(/function getBoardHeightLabelOption[\s\S]*?function getPercentPointLabelOption/)
+  assert.ok(boardLabelOption, 'board label option should exist')
+  assert.doesNotMatch(boardLabelOption[0], /backgroundColor|borderRadius|padding/, 'board stock labels should not use a white tag background')
 })
 
 test('yesterday feedback chart uses straight line series', () => {

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -9,6 +9,9 @@ test('board height chart displays stock labels from daily rows', () => {
   assert.match(source, /second_board_label/, 'second board labels should be used in the chart')
   assert.match(source, /gem_board_label/, 'GEM board labels should be used in the chart')
   assert.match(source, /function getBoardLabelFormatter/, 'chart point labels should have a formatter')
+  assert.match(source, /function shouldShowBoardHeightLabel/, 'labels should be filtered to avoid crowding')
+  assert.match(source, /function formatBoardHeightTooltip/, 'full labels should remain available in tooltip')
+  assert.match(source, /tooltip:\s*\{\s*trigger: 'axis',\s*formatter: formatBoardHeightTooltip/s)
   assert.match(source, /label:\s*getBoardHeightLabelOption\('max_board_label'\)/)
   assert.match(source, /label:\s*getBoardHeightLabelOption\('second_board_label'\)/)
   assert.match(source, /label:\s*getBoardHeightLabelOption\('gem_board_label', 'bottom'\)/)
@@ -23,4 +26,11 @@ test('yesterday feedback chart uses straight line series', () => {
   assert.match(optionSource, /name: '昨日连板平均涨幅'[\s\S]*?type: 'line'/)
   assert.doesNotMatch(optionSource, /smooth: true/, 'yesterday feedback lines should not be smoothed')
   assert.doesNotMatch(optionSource, /type: 'bar'/, 'yesterday feedback chart should not use bars')
+})
+
+test('ladder groups show seal rate and average change', () => {
+  assert.match(source, /封板率\s*\{\{\s*getLadderSealRate\(ladder\)\s*\}\}/)
+  assert.match(source, /均涨\s*\{\{\s*getLadderAverageChange\(ladder\)\s*\}\}/)
+  assert.match(source, /function getLadderSealRate\(ladder: MarketReviewLadderLevel\)/)
+  assert.match(source, /function getLadderAverageChange\(ladder: MarketReviewLadderLevel\)/)
 })

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -38,6 +38,41 @@ test('yesterday feedback chart uses straight line series', () => {
   assert.doesNotMatch(optionSource, /type: 'bar'/, 'yesterday feedback chart should not use bars')
 })
 
+test('promotion and yesterday feedback charts show direct percent readings', () => {
+  const promotionMatch = source.match(/promotionRateChart\?\.setOption\([\s\S]*?yesterdayChangeChart\?\.setOption/)
+  assert.ok(promotionMatch, 'promotion rate chart option should exist')
+  const promotionSource = promotionMatch[0]
+
+  assert.match(source, /function getPercentPointLabelOption/)
+  assert.match(source, /function formatPercentAxisLabel/)
+  assert.match(promotionSource, /min:\s*0/)
+  assert.match(promotionSource, /max:\s*100/)
+  assert.match(promotionSource, /label:\s*getPercentPointLabelOption\('top'\)/)
+  assert.match(promotionSource, /labelLayout:\s*\{\s*hideOverlap: true/s)
+
+  const yesterdayMatch = source.match(/yesterdayChangeChart\?\.setOption\([\s\S]*?limitTrendChart\?\.setOption/)
+  assert.ok(yesterdayMatch, 'yesterday feedback chart option should exist')
+  const yesterdaySource = yesterdayMatch[0]
+
+  assert.match(yesterdaySource, /label:\s*getPercentPointLabelOption\('top', true\)/)
+  assert.match(yesterdaySource, /label:\s*getPercentPointLabelOption\('bottom', true\)/)
+  assert.match(yesterdaySource, /markLine:\s*\{[\s\S]*yAxis:\s*0/s)
+})
+
+test('limit and broken amount chart uses hundred-million unit', () => {
+  const match = source.match(/amountChart\?\.setOption\([\s\S]*?\n  \)\n\}/)
+  assert.ok(match, 'amount chart option should exist')
+  const optionSource = match[0]
+
+  assert.match(source, /function toYiAmount/)
+  assert.match(source, /function formatYiAmount/)
+  assert.match(optionSource, /name:\s*'亿元'/)
+  assert.match(optionSource, /formatter:\s*\(value: number\) => formatYiAmount\(value\)/)
+  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiAmount\(row\.limit_up_amount\)\)/)
+  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiAmount\(row\.broken_amount\)\)/)
+  assert.match(optionSource, /valueFormatter:\s*\(value: unknown\) => formatYiAmount\(Number\(value\)\)/)
+})
+
 test('ladder groups show stats in a separate compact metrics row', () => {
   const match = source.match(/<div class="ladder-metrics">[\s\S]*?<\/div>/)
   assert.ok(match, 'ladder metrics row should exist')

--- a/frontend/tests/statisticsBoardLabels.test.mjs
+++ b/frontend/tests/statisticsBoardLabels.test.mjs
@@ -70,12 +70,13 @@ test('limit and broken amount chart uses hundred-million unit', () => {
   assert.ok(match, 'amount chart option should exist')
   const optionSource = match[0]
 
-  assert.match(source, /function toYiAmount/)
+  assert.match(source, /function toYiFromWanAmount/)
+  assert.match(source, /return Number\(\(value \/ 10000\)\.toFixed\(2\)\)/)
   assert.match(source, /function formatYiAmount/)
   assert.match(optionSource, /name:\s*'亿元'/)
   assert.match(optionSource, /formatter:\s*\(value: number\) => formatYiAmount\(value\)/)
-  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiAmount\(row\.limit_up_amount\)\)/)
-  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiAmount\(row\.broken_amount\)\)/)
+  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiFromWanAmount\(row\.limit_up_amount\)\)/)
+  assert.match(optionSource, /data:\s*dailyRows\.value\.map\(row => toYiFromWanAmount\(row\.broken_amount\)\)/)
   assert.match(optionSource, /valueFormatter:\s*\(value: unknown\) => formatYiAmount\(Number\(value\)\)/)
 })
 

--- a/frontend/tests/statisticsIntradayMode.test.mjs
+++ b/frontend/tests/statisticsIntradayMode.test.mjs
@@ -33,7 +33,10 @@ test('statistics view automatically merges live intraday data into the selected 
 })
 
 test('statistics view refreshes automatically without hiding historical comparison data', () => {
-  assert.match(statisticsSource, /window\.setInterval\(fetchData, 60000\)/, 'report should re-check market status every minute')
+  assert.match(statisticsSource, /window\.setInterval\(refreshReviewSilently, 60000\)/, 'report should re-check market status every minute')
+  assert.match(statisticsSource, /fetchData\(\{ silent: true \}\)/, 'timer refresh should not show the full-page loading mask')
+  assert.match(statisticsSource, /const shouldShowLoading = !options\.silent/)
+  assert.match(statisticsSource, /if \(shouldShowLoading\) \{\s*loading\.value = true\s*\}/)
   assert.match(statisticsSource, /clearReviewRefreshTimer\(\)/, 'timer should be cleared when view unmounts')
   assert.doesNotMatch(statisticsSource, /v-if="reviewMode === 'daily'"/, 'range picker should not be scoped to a removed mode')
   assert.match(statisticsSource, /盘中实时/, 'summary should identify live intraday data')

--- a/frontend/tests/statisticsIntradayMode.test.mjs
+++ b/frontend/tests/statisticsIntradayMode.test.mjs
@@ -10,22 +10,32 @@ test('market review API exposes intraday snapshot with detail and ladder payload
   assert.match(apiSource, /getMarketReviewIntraday/, 'intraday API function should be exported')
   assert.match(apiSource, /\/statistics\/review\/intraday/, 'intraday API should call the backend intraday endpoint')
   assert.match(typeSource, /interface MarketReviewIntradayResponse/, 'intraday response type should be explicit')
+  assert.match(typeSource, /is_live:\s*boolean/, 'intraday response should tell whether the snapshot is live market data')
   assert.match(typeSource, /detail:\s*MarketReviewDetailResponse/, 'intraday response should carry live detail data')
   assert.match(typeSource, /ladder:\s*MarketReviewLadderResponse/, 'intraday response should carry live ladder data')
 })
 
-test('statistics view has a distinct intraday mode that refreshes live report data', () => {
-  assert.match(statisticsSource, /const reviewMode = ref<'daily' \| 'intraday'>\('daily'\)/)
-  assert.match(statisticsSource, /label="intraday"[\s\S]*?盘中实时/)
-  assert.match(statisticsSource, /getMarketReviewIntraday\(dayjs\(\)\.format\('YYYY-MM-DD'\)\)/)
-  assert.match(statisticsSource, /detailResponse\.value = dailyResult\.detail/)
-  assert.match(statisticsSource, /ladderResponse\.value = dailyResult\.ladder/)
-  assert.match(statisticsSource, /window\.setInterval\(fetchData, 60000\)/, 'intraday mode should refresh every minute')
-  assert.match(statisticsSource, /clearIntradayRefreshTimer\(\)/, 'timer should be cleared when mode changes or view unmounts')
+test('statistics view automatically merges live intraday data into the selected daily range', () => {
+  assert.doesNotMatch(statisticsSource, /reviewMode/, 'manual close-review/intraday mode state should be removed')
+  assert.doesNotMatch(statisticsSource, /label="intraday"/, 'manual intraday button should not be rendered')
+  assert.doesNotMatch(statisticsSource, /label="daily"/, 'manual daily button should not be rendered')
+  assert.match(statisticsSource, /<el-radio-group v-model="timeRange" size="small">/, 'range picker should always be available')
+  assert.match(statisticsSource, /getMarketReviewDaily\(query\)/, 'daily history should be fetched for the selected range')
+  assert.match(statisticsSource, /getMarketReviewIntraday\(today\)/, 'today intraday snapshot should be checked automatically')
+  assert.match(
+    statisticsSource,
+    /if \(intradayResult\.is_live && intradayResult\.data\.rows\.length\)/,
+    'live intraday data should only be merged during live market time'
+  )
+  assert.match(statisticsSource, /mergeIntradayDailyRows/, 'today intraday row should be merged into historical rows')
+  assert.match(statisticsSource, /detailResponse\.value = intradayResult\.detail/)
+  assert.match(statisticsSource, /ladderResponse\.value = intradayResult\.ladder/)
 })
 
-test('daily range controls remain scoped to close-review mode', () => {
-  assert.match(statisticsSource, /v-if="reviewMode === 'daily'"/, 'range picker should only control daily close-review mode')
-  assert.match(statisticsSource, /盘中快照/, 'summary should identify intraday snapshot data')
-  assert.match(statisticsSource, /更新时间/, 'summary should display intraday update time')
+test('statistics view refreshes automatically without hiding historical comparison data', () => {
+  assert.match(statisticsSource, /window\.setInterval\(fetchData, 60000\)/, 'report should re-check market status every minute')
+  assert.match(statisticsSource, /clearReviewRefreshTimer\(\)/, 'timer should be cleared when view unmounts')
+  assert.doesNotMatch(statisticsSource, /v-if="reviewMode === 'daily'"/, 'range picker should not be scoped to a removed mode')
+  assert.match(statisticsSource, /盘中实时/, 'summary should identify live intraday data')
+  assert.match(statisticsSource, /实时更新/, 'summary should display live snapshot update time')
 })

--- a/frontend/tests/statisticsIntradayMode.test.mjs
+++ b/frontend/tests/statisticsIntradayMode.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const statisticsSource = readFileSync('src/views/Statistics.vue', 'utf8')
+const apiSource = readFileSync('src/api/review.ts', 'utf8')
+const typeSource = readFileSync('src/types/market.ts', 'utf8')
+
+test('market review API exposes intraday snapshot with detail and ladder payloads', () => {
+  assert.match(apiSource, /getMarketReviewIntraday/, 'intraday API function should be exported')
+  assert.match(apiSource, /\/statistics\/review\/intraday/, 'intraday API should call the backend intraday endpoint')
+  assert.match(typeSource, /interface MarketReviewIntradayResponse/, 'intraday response type should be explicit')
+  assert.match(typeSource, /detail:\s*MarketReviewDetailResponse/, 'intraday response should carry live detail data')
+  assert.match(typeSource, /ladder:\s*MarketReviewLadderResponse/, 'intraday response should carry live ladder data')
+})
+
+test('statistics view has a distinct intraday mode that refreshes live report data', () => {
+  assert.match(statisticsSource, /const reviewMode = ref<'daily' \| 'intraday'>\('daily'\)/)
+  assert.match(statisticsSource, /label="intraday"[\s\S]*?盘中实时/)
+  assert.match(statisticsSource, /getMarketReviewIntraday\(dayjs\(\)\.format\('YYYY-MM-DD'\)\)/)
+  assert.match(statisticsSource, /detailResponse\.value = dailyResult\.detail/)
+  assert.match(statisticsSource, /ladderResponse\.value = dailyResult\.ladder/)
+  assert.match(statisticsSource, /window\.setInterval\(fetchData, 60000\)/, 'intraday mode should refresh every minute')
+  assert.match(statisticsSource, /clearIntradayRefreshTimer\(\)/, 'timer should be cleared when mode changes or view unmounts')
+})
+
+test('daily range controls remain scoped to close-review mode', () => {
+  assert.match(statisticsSource, /v-if="reviewMode === 'daily'"/, 'range picker should only control daily close-review mode')
+  assert.match(statisticsSource, /盘中快照/, 'summary should identify intraday snapshot data')
+  assert.match(statisticsSource, /更新时间/, 'summary should display intraday update time')
+})

--- a/frontend/tests/useWebSocketSpeech.test.mjs
+++ b/frontend/tests/useWebSocketSpeech.test.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const source = readFileSync('src/composables/useWebSocket.ts', 'utf8')
+
+test('limit_up_alert websocket messages trigger speech announcement', () => {
+  const match = source.match(/case 'limit_up_alert':([\s\S]*?)break/)
+  assert.ok(match, 'limit_up_alert case should exist')
+  assert.match(
+    match[1],
+    /announceStock\s*\(/,
+    'limit_up_alert should call announceStock so the broadcast is spoken'
+  )
+})


### PR DESCRIPTION
## Summary
- add market review storage, aggregation, scheduler/backfill, and `/statistics/review/*` APIs
- refactor the statistics page to use the new review endpoints, charts, and detail/ladder views
- make the default market review source authoritative with fail-safe fallback and BJ 30% threshold handling

## Test Plan
- [x] `.\venv\Scripts\python.exe -m unittest tests.test_market_review_models tests.test_market_review_source_service tests.test_market_review_metrics_service tests.test_market_review_pipeline_service tests.test_market_review_scheduler tests.test_market_review_api -v`
- [x] `.\venv\Scripts\python.exe -m py_compile app\models\market_review.py app\schemas\market_review.py app\services\market_review_metrics_service.py app\services\market_review_source_service.py app\services\market_review_pipeline_service.py app\api\v1\review.py scripts\backfill_market_review.py`
- [x] `npx vite build`
- [x] local HTTP smoke test for `/api/v1/statistics/review/daily`, `/detail`, `/ladder`